### PR TITLE
Jass scoreboard rebuild: single-SVG slate with both Z's readable from both sides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ small apps for various use cases
 
 ## Apps Available
 
+### 🃏 Jass Scoreboard (Schiefertafel Z/Z)
+A browser-based digital Jass scoreboard that replicates a traditional Swiss chalk slate board with the classic Z/Z layout.
+
+**Features:**
+- Classic Z/Z slate board look with chalk tally marks (e.g. `||||\ ||||\ |`)
+- Two teams, editable names and target score (default 2500)
+- Win detection with animated overlay (gold glow, chalk particles)
+- Undo last entry, reset game, flip board orientation
+- Game state persisted to localStorage — resume on page reload
+- Responsive: works on mobile (320px+), tablet, and desktop
+- No external frameworks — pure HTML, CSS, Vanilla JS
+
+**Play:** [jass-scoreboard/index.html](jass-scoreboard/index.html)
+
 ### 🌍 GeoTriad - Geography Quiz Game
 A fun, educational geography quiz game for kids around 10 years old!
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ small apps for various use cases
 A browser-based digital Jass scoreboard that replicates a traditional Swiss chalk slate board with the classic Z/Z layout.
 
 **Features:**
-- Classic Z/Z slate board look with chalk tally marks (e.g. `||||\ ||||\ |`)
+- One SVG slate scene with two chalk Z's — both readable from both sides of the table (point-symmetric Z geometry, far half rotated 180°)
+- Classic Schieber chalk notation: 100s on the top bar (tally bundles `||||\`), 50s on the diagonal, 20s on the bottom bar, remainder as chalk number
+- Free score entry (1–500) plus quick chips (+20/+50/+100/+157)
 - Two teams, editable names and target score (default 2500)
 - Win detection with animated overlay (gold glow, chalk particles)
-- Undo last entry, reset game, flip board orientation
+- Undo last entry, reset game, rotate board orientation
 - Game state persisted to localStorage — resume on page reload
 - Responsive: works on mobile (320px+), tablet, and desktop
 - No external frameworks — pure HTML, CSS, Vanilla JS

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -1,0 +1,74 @@
+# Jass Scoreboard — Schiefertafel Z/Z
+
+A browser-based digital Jass scoreboard that replicates the look and feel of a traditional Swiss chalk slate board (Jasstafeln) with the classic Z/Z layout.
+
+## Features
+
+- 🎯 **Z/Z Board Layout** — Visual division of two mirrored team areas with red chalk guide lines
+- 📊 **Tally Mark Display** — Points shown as chalk tally marks (`||||\ ||||\ |`) instead of numbers
+- 🔢 **Numeric Totals** — Running totals displayed at the bottom of each panel
+- 🏆 **Win Detection** — Animated win overlay when a team exceeds the target score
+- ↩ **Undo** — Remove the last recorded entry
+- 🔄 **Reset** — Clear all scores while keeping team names and target score
+- ⇄ **Flip Board** — Swap panel positions for players on opposite sides of the table
+- 💾 **Persistence** — Game state saved to `localStorage` and restored on page reload
+- 📱 **Responsive** — Works on mobile (320px+), tablet, and desktop
+
+## Usage
+
+1. Open `index.html` in any modern browser (requires ES module support)
+2. Edit team names by clicking on the name fields at the top
+3. Set your target score (default: 2500)
+4. Select a team, enter points (1–500), and click **Eintragen**
+5. Use **↩ Rückgängig** to undo the last entry
+6. Use **🔄 Neu** to reset the game
+7. Use **⇄** to flip the board orientation
+
+## Project Structure
+
+```
+jass-scoreboard/
+├── index.html          # Root HTML structure
+├── css/
+│   └── styles.css      # Chalk board styling, Z/Z grid, animations
+├── js/
+│   ├── app.js          # Application bootstrap
+│   ├── state.js        # Global state definition and mutations
+│   ├── storage.js      # localStorage persistence
+│   ├── scoring.js      # Score entry, totals, win check
+│   ├── renderer.js     # Board, tallies, totals, win state rendering
+│   └── ui.js           # Event binding and input validation
+├── assets/
+│   ├── textures/       # (placeholder for optional slate texture)
+│   └── fonts/          # (placeholder for optional chalk fonts)
+└── README.md
+```
+
+## Technologies
+
+- HTML5
+- CSS3
+- Vanilla JavaScript (ES6 modules)
+
+No external frameworks or libraries are used.
+
+## Game Rules
+
+- Two teams record scores round by round
+- A team wins when its total **exceeds** the target score
+- Default target: **2500 points**
+- Valid point entries: integers from 1 to 500
+- After a win, score entry is disabled but undo remains available
+
+## Tally Mark Rendering
+
+Points are displayed as tally marks:
+
+| Points | Display               |
+|--------|-----------------------|
+| 3      | `\| \| \|`            |
+| 5      | `\|\|\|\|\ `          |
+| 7      | `\|\|\|\|\  \| \|`    |
+| 10     | `\|\|\|\|\  \|\|\|\|\ ` |
+
+Groups of 5 are rendered as `||||\ ` and remainders as `| `.

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -1,74 +1,85 @@
-# Jass Scoreboard — Schiefertafel Z/Z
+# Jass Tafel — Schiefertafel Z/Z
 
-A browser-based digital Jass scoreboard that replicates the look and feel of a traditional Swiss chalk slate board (Jasstafeln) with the classic Z/Z layout.
+A browser-based digital Jass scoreboard that replicates a traditional Swiss chalk
+slate board (Jasstafel). The whole board is rendered as **one SVG slate scene**
+with two chalk **Z** shapes — one per team — exactly like the physical board
+lying flat on the table between the two teams.
+
+## The two Z's are readable from both sides
+
+Like a real Jasstafel, the board is meant to sit between players facing each
+other. Two things make it work:
+
+1. **Each Z is drawn point-symmetric about its own centre** — the top bar, the
+   diagonal and the bottom bar map exactly onto themselves under a 180°
+   rotation. A "Z" viewed upside down is still a "Z" (never an "S").
+2. **The far half of the slate is rotated 180°**, so the far team's name,
+   total and marks face the player sitting across the table.
+
+The result: from *either* side of the table you always see two proper Z's, and
+each team reads its own name and total the right way up. The ⇅ button rotates
+the board (swaps which team sits at the near edge) without touching the data.
+
+## Chalk notation
+
+Scores are entered as normal round values (1–500). The board decomposes each
+team's running total into the classic Schieber chalk notation:
+
+| Line | Value per mark |
+|---|---|
+| Top bar | 100 points (bundled tally-style: `||||\` per 500) |
+| Diagonal | 50 points |
+| Bottom bar | 20 points |
+| Chalk number | remainder below 20 (e.g. `+ 17`) |
+
+The board is always kept canonical — five twenties are automatically
+"exchanged" for a hundred, like a tidy chalk writer would do.
 
 ## Features
 
-- 🎯 **Z/Z Board Layout** — Visual division of two mirrored team areas with red chalk guide lines
-- 📊 **Tally Mark Display** — Points shown as chalk tally marks (`||||\ ||||\ |`) instead of numbers
-- 🔢 **Numeric Totals** — Running totals displayed at the bottom of each panel
-- 🏆 **Win Detection** — Animated win overlay when a team exceeds the target score
-- ↩ **Undo** — Remove the last recorded entry
-- 🔄 **Reset** — Clear all scores while keeping team names and target score
-- ⇄ **Flip Board** — Swap panel positions for players on opposite sides of the table
-- 💾 **Persistence** — Game state saved to `localStorage` and restored on page reload
-- 📱 **Responsive** — Works on mobile (320px+), tablet, and desktop
+- 🧮 **Free score entry** — any 1–500 points per round, plus quick chips (+20/+50/+100/+157)
+- ✏️ **Chalk marks derived from totals** — authentic 100/50/20 notation on the Z lines
+- 🔄 **Deterministic chalk jitter** — hand-drawn look that stays stable across re-renders
+- 🏆 **Win detection** — a team wins by *exceeding* the target (default 2500)
+- ↩ **Undo** — remove the last recorded round (also after a win)
+- 🆕 **Reset** — clear scores, keep team names / target / orientation
+- ⇅ **Rotate board** — swap which team faces the near edge
+- 💾 **Persistence** — state saved to `localStorage` (`jassScoreboardState`), old-format entries are migrated
+- 📱 **Responsive** — mobile (320px+), tablet, desktop
+- ♿ **Accessible** — keyboard operable, live screen-reader status, reduced-motion support
 
 ## Usage
 
-1. Open `index.html` in any modern browser (requires ES module support)
-2. Edit team names by clicking on the name fields at the top
-3. Set your target score (default: 2500)
-4. Select a team, enter points (1–500), and click **Eintragen**
-5. Use **↩ Rückgängig** to undo the last entry
-6. Use **🔄 Neu** to reset the game
-7. Use **⇄** to flip the board orientation
+1. Open `index.html` via any static web server (ES modules require http, e.g. `python3 -m http.server`)
+2. Edit team names and the target score at the top
+3. Select a team, type the round points (or tap a quick chip)
+4. **Eintragen** records the round; **↩ Rückgängig** undoes; **🔄 Neu** resets
+5. **⇅** rotates the board for the players on the other side of the table
 
 ## Project Structure
 
 ```
 jass-scoreboard/
-├── index.html          # Root HTML structure
+├── index.html          # Root HTML structure, DOM containers
 ├── css/
-│   └── styles.css      # Chalk board styling, Z/Z grid, animations
+│   └── styles.css      # Slate/chalk styling, layout, animations
 ├── js/
 │   ├── app.js          # Application bootstrap
 │   ├── state.js        # Global state definition and mutations
-│   ├── storage.js      # localStorage persistence
-│   ├── scoring.js      # Score entry, totals, win check
-│   ├── renderer.js     # Board, tallies, totals, win state rendering
+│   ├── storage.js      # localStorage persistence + legacy migration
+│   ├── scoring.js      # Validation, totals, win check, chalk decomposition
+│   ├── renderer.js     # Single-SVG slate scene: Z's, marks, totals, win state
 │   └── ui.js           # Event binding and input validation
-├── assets/
-│   ├── textures/       # (placeholder for optional slate texture)
-│   └── fonts/          # (placeholder for optional chalk fonts)
 └── README.md
 ```
 
 ## Technologies
 
-- HTML5
-- CSS3
-- Vanilla JavaScript (ES6 modules)
-
-No external frameworks or libraries are used.
+HTML5, CSS3, Vanilla JavaScript (ES6 modules). No frameworks, no external libraries.
 
 ## Game Rules
 
 - Two teams record scores round by round
-- A team wins when its total **exceeds** the target score
-- Default target: **2500 points**
+- A team wins when its total **exceeds** the target score (default **2500**)
 - Valid point entries: integers from 1 to 500
-- After a win, score entry is disabled but undo remains available
-
-## Tally Mark Rendering
-
-Points are displayed as tally marks:
-
-| Points | Display               |
-|--------|-----------------------|
-| 3      | `\| \| \|`            |
-| 5      | `\|\|\|\|\ `          |
-| 7      | `\|\|\|\|\  \| \|`    |
-| 10     | `\|\|\|\|\  \|\|\|\|\ ` |
-
-Groups of 5 are rendered as `||||\ ` and remainders as `| `.
+- After a win, score entry is disabled; undo and reset remain available

--- a/jass-scoreboard/css/styles.css
+++ b/jass-scoreboard/css/styles.css
@@ -1,0 +1,534 @@
+/* styles.css — Jass Scoreboard chalk slate styling */
+
+/* ─── Reset & Base ────────────────────────────────────────────── */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --slate-bg:        #1a2a1a;
+  --slate-surface:   #1e321e;
+  --chalk-white:     #f0ede0;
+  --chalk-dim:       #c8c4b0;
+  --chalk-red:       #e05050;
+  --panel-border:    rgba(255, 255, 255, 0.12);
+  --input-bg:        #243224;
+  --input-border:    rgba(240, 237, 224, 0.3);
+  --btn-primary:     #4a7c59;
+  --btn-primary-h:   #5a9c6e;
+  --btn-secondary:   #3a5a4a;
+  --btn-danger:      #7a3535;
+  --btn-danger-h:    #9a4545;
+  --winner-glow:     #ffd700;
+  --font-main:       'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --radius:          6px;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  background-color: var(--slate-bg);
+  background-image:
+    radial-gradient(ellipse at 20% 30%, rgba(255,255,255,0.02) 0%, transparent 60%),
+    radial-gradient(ellipse at 80% 70%, rgba(255,255,255,0.015) 0%, transparent 60%);
+  color: var(--chalk-white);
+  font-family: var(--font-main);
+  min-height: 100vh;
+  min-width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ─── Screen-reader only utility ─────────────────────────────── */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ─── App wrapper ─────────────────────────────────────────────── */
+.app-wrapper {
+  width: 100%;
+  max-width: 760px;
+  padding: 12px 12px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ─── Header ──────────────────────────────────────────────────── */
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 2px solid var(--chalk-red);
+}
+
+.header-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--chalk-white);
+  text-shadow: 0 0 12px rgba(240,237,224,0.35);
+}
+
+.header-settings {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.setting-label {
+  font-size: 0.85rem;
+  color: var(--chalk-dim);
+}
+
+.setting-input {
+  width: 80px;
+  padding: 4px 8px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
+  color: var(--chalk-white);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.setting-input:focus {
+  outline: 2px solid var(--chalk-dim);
+  outline-offset: 1px;
+}
+
+/* ─── Name editors ────────────────────────────────────────────── */
+.name-editors {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.name-editor-group {
+  flex: 1;
+}
+
+.team-name-input {
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px dashed rgba(240,237,224,0.3);
+  color: var(--chalk-white);
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: 0.04em;
+  transition: border-color 0.2s;
+}
+
+.team-name-input:focus {
+  outline: none;
+  border-bottom-color: var(--chalk-white);
+}
+
+.name-editor-divider {
+  color: var(--chalk-dim);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+/* ─── Board (Z/Z grid) ────────────────────────────────────────── */
+.board {
+  display: grid;
+  grid-template-columns: 1fr 60px 1fr;
+  min-height: 340px;
+  background: var(--slate-surface);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  /* Subtle noise texture overlay via box-shadow */
+  box-shadow:
+    inset 0 0 60px rgba(0,0,0,0.35),
+    0 4px 20px rgba(0,0,0,0.5);
+}
+
+/* ─── Board panels ────────────────────────────────────────────── */
+.board-panel {
+  padding: 16px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  transition: box-shadow 0.4s ease;
+}
+
+.panel-left {
+  border-right: none;
+}
+
+.panel-right {
+  border-left: none;
+}
+
+/* Winner highlight */
+.winner-panel {
+  box-shadow:
+    inset 0 0 40px rgba(255, 215, 0, 0.18),
+    inset 0 0 10px rgba(255, 215, 0, 0.08);
+  animation: panelPulse 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes panelPulse {
+  from { box-shadow: inset 0 0 40px rgba(255,215,0,0.12), inset 0 0 10px rgba(255,215,0,0.06); }
+  to   { box-shadow: inset 0 0 60px rgba(255,215,0,0.28), inset 0 0 20px rgba(255,215,0,0.14); }
+}
+
+/* ─── Chalk text ──────────────────────────────────────────────── */
+.chalk-text {
+  color: var(--chalk-white);
+  text-rendering: geometricPrecision;
+}
+
+/* ─── Team name inside panel ─────────────────────────────────── */
+.panel-team-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-align: center;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba(224, 80, 80, 0.45);
+  text-shadow: 0 0 8px rgba(240,237,224,0.3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Entries area (tally marks) ─────────────────────────────── */
+.entries-area {
+  flex: 1;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  letter-spacing: 0.05em;
+  overflow-y: auto;
+  word-break: break-word;
+  min-height: 120px;
+  padding: 4px 2px;
+  color: var(--chalk-dim);
+}
+
+.tally-row {
+  padding: 1px 0;
+  white-space: nowrap;
+}
+
+.no-entries {
+  color: rgba(240,237,224,0.2);
+  font-size: 1.2rem;
+}
+
+/* ─── Total row ───────────────────────────────────────────────── */
+.panel-total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 8px;
+  border-top: 1px solid rgba(224, 80, 80, 0.45);
+}
+
+.total-label {
+  font-size: 0.8rem;
+  color: var(--chalk-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.total-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-shadow: 0 0 10px rgba(240,237,224,0.4);
+}
+
+/* ─── Z/Z Divider ─────────────────────────────────────────────── */
+.board-divider {
+  display: flex;
+  align-items: stretch;
+  position: relative;
+}
+
+.z-divider-svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ─── Score input area ────────────────────────────────────────── */
+.score-input-area {
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.score-input-area.disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.select-team {
+  flex: 1;
+  min-width: 100px;
+  padding: 10px 10px;
+  background: var(--slate-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
+  color: var(--chalk-white);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.select-team:focus {
+  outline: 2px solid var(--chalk-dim);
+  outline-offset: 1px;
+}
+
+.points-input {
+  flex: 2;
+  min-width: 80px;
+  padding: 10px 12px;
+  background: var(--slate-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
+  color: var(--chalk-white);
+  font-size: 1rem;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.points-input:focus {
+  outline: none;
+  border-color: var(--chalk-white);
+}
+
+/* ─── Buttons ─────────────────────────────────────────────────── */
+.btn {
+  padding: 10px 18px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, transform 0.1s;
+  white-space: nowrap;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--chalk-white);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: var(--btn-primary);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.btn-primary:hover {
+  background: var(--btn-primary-h);
+}
+
+.btn-secondary {
+  background: var(--btn-secondary);
+  color: var(--chalk-white);
+}
+
+.btn-secondary:hover {
+  background: #4a7a6a;
+}
+
+.btn-danger {
+  background: var(--btn-danger);
+  color: var(--chalk-white);
+}
+
+.btn-danger:hover {
+  background: var(--btn-danger-h);
+}
+
+.btn-icon {
+  background: transparent;
+  border: 1px solid var(--input-border);
+  color: var(--chalk-white);
+  padding: 6px 12px;
+  font-size: 1.1rem;
+}
+
+.btn-icon:hover {
+  background: rgba(255,255,255,0.08);
+}
+
+/* ─── Action row ──────────────────────────────────────────────── */
+.action-row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* ─── Error message ───────────────────────────────────────────── */
+.error-msg {
+  min-height: 1.2em;
+  font-size: 0.85rem;
+  color: #ff8080;
+  opacity: 0;
+  transition: opacity 0.25s;
+  text-align: center;
+}
+
+.error-msg.visible {
+  opacity: 1;
+}
+
+/* ─── Win overlay ─────────────────────────────────────────────── */
+#win-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 25, 10, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+  backdrop-filter: blur(3px);
+}
+
+#win-overlay.active {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.win-content {
+  text-align: center;
+  animation: winPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes winPop {
+  from { transform: scale(0.5); opacity: 0; }
+  to   { transform: scale(1);   opacity: 1; }
+}
+
+.win-icon {
+  font-size: 4rem;
+  margin-bottom: 12px;
+  animation: winSpin 0.8s ease-out;
+}
+
+@keyframes winSpin {
+  from { transform: rotate(-20deg) scale(0.6); }
+  to   { transform: rotate(0deg)   scale(1); }
+}
+
+#win-overlay h2 {
+  font-size: 2.8rem;
+  color: var(--winner-glow);
+  text-shadow: 0 0 24px rgba(255,215,0,0.7);
+  margin-bottom: 10px;
+  letter-spacing: 0.1em;
+}
+
+.win-team {
+  font-size: 1.8rem;
+  color: var(--chalk-white);
+  text-shadow: 0 0 16px rgba(240,237,224,0.6);
+  margin-bottom: 16px;
+}
+
+.win-hint {
+  font-size: 0.8rem;
+  color: var(--chalk-dim);
+  opacity: 0.7;
+  margin-top: 18px;
+}
+
+/* ─── Chalk dust particles ────────────────────────────────────── */
+.chalk-particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.chalk-particles span {
+  position: absolute;
+  display: block;
+  width: 6px;
+  height: 6px;
+  background: rgba(240, 237, 224, 0.6);
+  border-radius: 50%;
+  animation: float 3s ease-in-out infinite;
+}
+
+.chalk-particles span:nth-child(1)  { left: 10%; top: 20%; animation-delay: 0s;    animation-duration: 2.8s; width: 4px;  height: 4px; }
+.chalk-particles span:nth-child(2)  { left: 25%; top: 60%; animation-delay: 0.4s;  animation-duration: 3.2s; }
+.chalk-particles span:nth-child(3)  { left: 45%; top: 15%; animation-delay: 0.8s;  animation-duration: 2.5s; width: 8px;  height: 8px; }
+.chalk-particles span:nth-child(4)  { left: 65%; top: 70%; animation-delay: 1.2s;  animation-duration: 3.6s; width: 5px;  height: 5px; }
+.chalk-particles span:nth-child(5)  { left: 80%; top: 30%; animation-delay: 0.2s;  animation-duration: 2.9s; }
+.chalk-particles span:nth-child(6)  { left: 90%; top: 80%; animation-delay: 1.6s;  animation-duration: 3.4s; width: 3px;  height: 3px; }
+.chalk-particles span:nth-child(7)  { left: 55%; top: 45%; animation-delay: 0.6s;  animation-duration: 2.6s; width: 7px;  height: 7px; }
+.chalk-particles span:nth-child(8)  { left: 35%; top: 85%; animation-delay: 1.0s;  animation-duration: 3.0s; }
+.chalk-particles span:nth-child(9)  { left: 72%; top: 10%; animation-delay: 1.4s;  animation-duration: 2.7s; width: 5px;  height: 5px; }
+
+@keyframes float {
+  0%   { transform: translateY(0)   rotate(0deg);   opacity: 0.8; }
+  50%  { transform: translateY(-30px) rotate(180deg); opacity: 0.4; }
+  100% { transform: translateY(-60px) rotate(360deg); opacity: 0; }
+}
+
+/* ─── Responsive ──────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .app-wrapper { padding: 8px 8px 20px; }
+  .header-title { font-size: 1.3rem; }
+  .board { grid-template-columns: 1fr 44px 1fr; }
+  .panel-team-name { font-size: 0.95rem; }
+  .entries-area { font-size: 0.82rem; }
+  .total-value { font-size: 1.15rem; }
+  .input-row { flex-direction: column; }
+  .select-team, .points-input, .btn-primary { width: 100%; }
+  #win-overlay h2 { font-size: 2rem; }
+  .win-team { font-size: 1.3rem; }
+}
+
+@media (min-width: 600px) {
+  .board { min-height: 400px; }
+  .entries-area { font-size: 1rem; }
+}
+
+/* ─── Scrollbar styling ───────────────────────────────────────── */
+.entries-area::-webkit-scrollbar { width: 4px; }
+.entries-area::-webkit-scrollbar-track { background: transparent; }
+.entries-area::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }

--- a/jass-scoreboard/css/styles.css
+++ b/jass-scoreboard/css/styles.css
@@ -220,28 +220,17 @@ body {
   white-space: nowrap;
 }
 
-/* ─── Entries area (tally marks) ─────────────────────────────── */
-.entries-area {
+/* ─── Z SVG area (filled by renderer.js) ─────────────────────── */
+.z-svg-area {
   flex: 1;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 0.95rem;
-  line-height: 1.7;
-  letter-spacing: 0.05em;
-  word-break: break-word;
-  padding: 6px 4px;
-  color: var(--chalk-dim);
-  position: relative;
-  z-index: 1;
+  min-height: 110px;
+  overflow: hidden;
 }
 
-.tally-row {
-  padding: 1px 0;
-  white-space: nowrap;
-}
-
-.no-entries {
-  color: rgba(240,237,224,0.2);
-  font-size: 1.2rem;
+.z-svg-area svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 /* ─── Total row ───────────────────────────────────────────────── */
@@ -282,7 +271,6 @@ body {
   height: 100%;
   pointer-events: none;
 }
-
 /* ─── Score input area ────────────────────────────────────────── */
 .score-input-area {
   background: var(--input-bg);
@@ -299,46 +287,88 @@ body {
   pointer-events: none;
 }
 
-.input-row {
+/* ─── Team toggle row ─────────────────────────────────────────── */
+.team-toggle-row {
   display: flex;
   gap: 8px;
-  align-items: center;
-  flex-wrap: wrap;
 }
 
-.select-team {
+.btn-team {
   flex: 1;
-  min-width: 100px;
-  padding: 10px 10px;
-  background: var(--slate-bg);
+  padding: 10px 8px;
+  background: var(--input-bg);
   border: 1px solid var(--input-border);
   border-radius: var(--radius);
-  color: var(--chalk-white);
+  color: var(--chalk-dim);
   font-size: 0.95rem;
+  font-weight: 600;
   cursor: pointer;
+  transition: background 0.18s, color 0.18s, border-color 0.18s;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.select-team:focus {
-  outline: 2px solid var(--chalk-dim);
-  outline-offset: 1px;
+.btn-team.is-active {
+  background: var(--btn-primary);
+  color: #fff;
+  border-color: var(--btn-primary-h);
 }
 
-.points-input {
-  flex: 2;
-  min-width: 80px;
-  padding: 10px 12px;
-  background: var(--slate-bg);
-  border: 1px solid var(--input-border);
-  border-radius: var(--radius);
+.btn-team:hover:not(.is-active) {
+  background: rgba(255,255,255,0.06);
   color: var(--chalk-white);
-  font-size: 1rem;
-  text-align: center;
-  transition: border-color 0.2s;
 }
 
-.points-input:focus {
-  outline: none;
-  border-color: var(--chalk-white);
+/* ─── Mark buttons (+100 / +50 / +20) ────────────────────────── */
+.mark-row {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-mark {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 12px 6px;
+  background: var(--slate-surface);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.18s, transform 0.1s, border-color 0.18s;
+}
+
+.btn-mark:hover {
+  background: rgba(255,255,255,0.07);
+  border-color: rgba(240,237,224,0.3);
+}
+
+.btn-mark:active {
+  transform: scale(0.95);
+  background: rgba(255,255,255,0.12);
+}
+
+.btn-mark:focus-visible {
+  outline: 2px solid var(--chalk-white);
+  outline-offset: 2px;
+}
+
+.mark-pts {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--chalk-white);
+  text-shadow: 0 0 8px rgba(240,237,224,0.3);
+  letter-spacing: 0.04em;
+}
+
+.mark-lbl {
+  font-size: 0.7rem;
+  color: var(--chalk-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
 }
 
 /* ─── Buttons ─────────────────────────────────────────────────── */
@@ -526,20 +556,12 @@ body {
   .app-wrapper { padding: 8px 8px 20px; }
   .header-title { font-size: 1.3rem; }
   .panel-team-name { font-size: 0.95rem; }
-  .entries-area { font-size: 0.82rem; }
   .total-value { font-size: 1.15rem; }
-  .input-row { flex-direction: column; }
-  .select-team, .points-input, .btn-primary { width: 100%; }
+  .mark-pts { font-size: 1.1rem; }
   #win-overlay h2 { font-size: 2rem; }
   .win-team { font-size: 1.3rem; }
 }
 
 @media (min-width: 600px) {
   .board { min-height: 480px; }
-  .entries-area { font-size: 1rem; }
 }
-
-/* ─── Scrollbar styling (z-wrapper) ──────────────────────────── */
-.z-wrapper::-webkit-scrollbar { width: 4px; }
-.z-wrapper::-webkit-scrollbar-track { background: transparent; }
-.z-wrapper::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }

--- a/jass-scoreboard/css/styles.css
+++ b/jass-scoreboard/css/styles.css
@@ -146,16 +146,15 @@ body {
   flex-shrink: 0;
 }
 
-/* ─── Board (Z/Z grid) ────────────────────────────────────────── */
+/* ─── Board (Z/Z grid — two stacked panels) ──────────────────── */
 .board {
   display: grid;
-  grid-template-columns: 1fr 60px 1fr;
-  min-height: 340px;
+  grid-template-rows: 1fr auto 1fr;
+  min-height: 420px;
   background: var(--slate-surface);
   border: 1px solid var(--panel-border);
   border-radius: var(--radius);
   overflow: hidden;
-  /* Subtle noise texture overlay via box-shadow */
   box-shadow:
     inset 0 0 60px rgba(0,0,0,0.35),
     0 4px 20px rgba(0,0,0,0.5);
@@ -171,12 +170,21 @@ body {
   transition: box-shadow 0.4s ease;
 }
 
-.panel-left {
-  border-right: none;
+/* Bottom panel rotated 180° so the opposing player can read it */
+.panel-bottom {
+  transform: rotate(180deg);
 }
 
-.panel-right {
-  border-left: none;
+/* Horizontal red chalk line between the two Z panels */
+.board-h-divider {
+  height: 3px;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    rgba(224, 80, 80, 0.7) 15%,
+    rgba(224, 80, 80, 0.7) 85%,
+    transparent 100%
+  );
 }
 
 /* Winner highlight */
@@ -219,11 +227,11 @@ body {
   font-size: 0.95rem;
   line-height: 1.7;
   letter-spacing: 0.05em;
-  overflow-y: auto;
   word-break: break-word;
-  min-height: 120px;
-  padding: 4px 2px;
+  padding: 6px 4px;
   color: var(--chalk-dim);
+  position: relative;
+  z-index: 1;
 }
 
 .tally-row {
@@ -259,16 +267,20 @@ body {
   text-shadow: 0 0 10px rgba(240,237,224,0.4);
 }
 
-/* ─── Z/Z Divider ─────────────────────────────────────────────── */
-.board-divider {
-  display: flex;
-  align-items: stretch;
+/* ─── Z wrapper — contains SVG guide lines + tally entries ───── */
+.z-wrapper {
   position: relative;
+  flex: 1;
+  min-height: 110px;
+  overflow-y: auto;
 }
 
-.z-divider-svg {
+.z-lines {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+  pointer-events: none;
 }
 
 /* ─── Score input area ────────────────────────────────────────── */
@@ -513,7 +525,6 @@ body {
 @media (max-width: 480px) {
   .app-wrapper { padding: 8px 8px 20px; }
   .header-title { font-size: 1.3rem; }
-  .board { grid-template-columns: 1fr 44px 1fr; }
   .panel-team-name { font-size: 0.95rem; }
   .entries-area { font-size: 0.82rem; }
   .total-value { font-size: 1.15rem; }
@@ -524,11 +535,11 @@ body {
 }
 
 @media (min-width: 600px) {
-  .board { min-height: 400px; }
+  .board { min-height: 480px; }
   .entries-area { font-size: 1rem; }
 }
 
-/* ─── Scrollbar styling ───────────────────────────────────────── */
-.entries-area::-webkit-scrollbar { width: 4px; }
-.entries-area::-webkit-scrollbar-track { background: transparent; }
-.entries-area::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }
+/* ─── Scrollbar styling (z-wrapper) ──────────────────────────── */
+.z-wrapper::-webkit-scrollbar { width: 4px; }
+.z-wrapper::-webkit-scrollbar-track { background: transparent; }
+.z-wrapper::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 4px; }

--- a/jass-scoreboard/css/styles.css
+++ b/jass-scoreboard/css/styles.css
@@ -1,6 +1,6 @@
-/* styles.css — Jass Scoreboard chalk slate styling */
+/* styles.css — Jass Tafel: one slate, two Z's, chalk look */
 
-/* ─── Reset & Base ────────────────────────────────────────────── */
+/* ─── Reset & base ────────────────────────────────────────────── */
 *, *::before, *::after {
   box-sizing: border-box;
   margin: 0;
@@ -8,22 +8,26 @@
 }
 
 :root {
-  --slate-bg:        #1a2a1a;
-  --slate-surface:   #1e321e;
-  --chalk-white:     #f0ede0;
-  --chalk-dim:       #c8c4b0;
-  --chalk-red:       #e05050;
-  --panel-border:    rgba(255, 255, 255, 0.12);
-  --input-bg:        #243224;
-  --input-border:    rgba(240, 237, 224, 0.3);
-  --btn-primary:     #4a7c59;
-  --btn-primary-h:   #5a9c6e;
-  --btn-secondary:   #3a5a4a;
-  --btn-danger:      #7a3535;
-  --btn-danger-h:    #9a4545;
-  --winner-glow:     #ffd700;
-  --font-main:       'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  --radius:          6px;
+  --page-bg:       #21262b;
+  --slate:         #232e28;
+  --slate-deep:    #1b241f;
+  --chalk:         #f2efe4;
+  --chalk-dim:     #c9c5b2;
+  --paint-red:     #d84a43;
+  --paint-red-dim: rgba(216, 74, 67, 0.55);
+  --wood:          #6d4a2f;
+  --wood-dark:     #543823;
+  --input-bg:      #2b333a;
+  --input-border:  rgba(242, 239, 228, 0.28);
+  --btn-primary:   #4a7c59;
+  --btn-primary-h: #5a9c6e;
+  --btn-secondary: #3c4a55;
+  --btn-danger:    #7a3535;
+  --btn-danger-h:  #9a4545;
+  --winner-glow:   #ffd75a;
+  --font-ui:       'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --font-chalk:    'Segoe Print', 'Bradley Hand', 'Chalkboard SE', 'Comic Sans MS', cursive;
+  --radius:        8px;
 }
 
 html, body {
@@ -31,35 +35,33 @@ html, body {
 }
 
 body {
-  background-color: var(--slate-bg);
+  background-color: var(--page-bg);
   background-image:
-    radial-gradient(ellipse at 20% 30%, rgba(255,255,255,0.02) 0%, transparent 60%),
-    radial-gradient(ellipse at 80% 70%, rgba(255,255,255,0.015) 0%, transparent 60%);
-  color: var(--chalk-white);
-  font-family: var(--font-main);
+    radial-gradient(ellipse at 25% 20%, rgba(255,255,255,0.03) 0%, transparent 55%),
+    radial-gradient(ellipse at 75% 80%, rgba(255,255,255,0.02) 0%, transparent 55%);
+  color: var(--chalk);
+  font-family: var(--font-ui);
   min-height: 100vh;
-  min-width: 320px;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  justify-content: center;
 }
 
-/* ─── Screen-reader only utility ─────────────────────────────── */
 .sr-only {
   position: absolute;
-  width: 1px; height: 1px;
-  padding: 0; margin: -1px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0 0 0 0);
   white-space: nowrap;
   border: 0;
 }
 
-/* ─── App wrapper ─────────────────────────────────────────────── */
 .app-wrapper {
   width: 100%;
-  max-width: 760px;
-  padding: 12px 12px 24px;
+  max-width: 540px;
+  padding: 12px 12px 28px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -70,17 +72,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 8px 4px;
-  border-bottom: 2px solid var(--chalk-red);
+  gap: 10px;
 }
 
 .header-title {
-  font-size: 1.6rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  color: var(--chalk-white);
-  text-shadow: 0 0 12px rgba(240,237,224,0.35);
+  font-family: var(--font-chalk);
+  font-size: 1.5rem;
+  letter-spacing: 0.03em;
 }
 
 .header-settings {
@@ -95,291 +93,166 @@ body {
 }
 
 .setting-input {
-  width: 80px;
-  padding: 4px 8px;
+  width: 84px;
+  padding: 8px;
+  font-size: 1rem;
   background: var(--input-bg);
+  color: var(--chalk);
   border: 1px solid var(--input-border);
   border-radius: var(--radius);
-  color: var(--chalk-white);
-  font-size: 0.9rem;
-  text-align: center;
 }
 
-.setting-input:focus {
-  outline: 2px solid var(--chalk-dim);
-  outline-offset: 1px;
-}
-
-/* ─── Name editors ────────────────────────────────────────────── */
+/* ─── Team name editors ───────────────────────────────────────── */
 .name-editors {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.name-editor-group {
-  flex: 1;
-}
-
 .team-name-input {
-  width: 100%;
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  border-bottom: 1px dashed rgba(240,237,224,0.3);
-  color: var(--chalk-white);
-  font-size: 1rem;
-  font-weight: 600;
-  text-align: center;
-  letter-spacing: 0.04em;
-  transition: border-color 0.2s;
-}
-
-.team-name-input:focus {
-  outline: none;
-  border-bottom-color: var(--chalk-white);
+  flex: 1;
+  min-width: 0;
+  padding: 9px 10px;
+  font-size: 0.95rem;
+  background: var(--input-bg);
+  color: var(--chalk);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
 }
 
 .name-editor-divider {
   color: var(--chalk-dim);
   font-size: 0.8rem;
-  flex-shrink: 0;
 }
 
-/* ─── Board (Z/Z grid — two stacked panels) ──────────────────── */
-.board {
-  display: grid;
-  grid-template-rows: 1fr auto 1fr;
-  min-height: 420px;
-  background: var(--slate-surface);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius);
-  overflow: hidden;
-  box-shadow:
-    inset 0 0 60px rgba(0,0,0,0.35),
-    0 4px 20px rgba(0,0,0,0.5);
-}
-
-/* ─── Board panels ────────────────────────────────────────────── */
-.board-panel {
-  padding: 16px 14px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 0;
-  transition: box-shadow 0.4s ease;
-}
-
-/* Bottom panel rotated 180° so the opposing player can read it */
-.panel-bottom {
-  transform: rotate(180deg);
-}
-
-/* Horizontal red chalk line between the two Z panels */
-.board-h-divider {
-  height: 3px;
-  background: linear-gradient(
-    to right,
-    transparent 0%,
-    rgba(224, 80, 80, 0.7) 15%,
-    rgba(224, 80, 80, 0.7) 85%,
-    transparent 100%
-  );
-}
-
-/* Winner highlight */
-.winner-panel {
-  box-shadow:
-    inset 0 0 40px rgba(255, 215, 0, 0.18),
-    inset 0 0 10px rgba(255, 215, 0, 0.08);
-  animation: panelPulse 1.6s ease-in-out infinite alternate;
-}
-
-@keyframes panelPulse {
-  from { box-shadow: inset 0 0 40px rgba(255,215,0,0.12), inset 0 0 10px rgba(255,215,0,0.06); }
-  to   { box-shadow: inset 0 0 60px rgba(255,215,0,0.28), inset 0 0 20px rgba(255,215,0,0.14); }
-}
-
-/* ─── Chalk text ──────────────────────────────────────────────── */
-.chalk-text {
-  color: var(--chalk-white);
-  text-rendering: geometricPrecision;
-}
-
-/* ─── Team name inside panel ─────────────────────────────────── */
-.panel-team-name {
-  font-size: 1.1rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-align: center;
-  padding-bottom: 6px;
-  border-bottom: 1px solid rgba(224, 80, 80, 0.45);
-  text-shadow: 0 0 8px rgba(240,237,224,0.3);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* ─── Z SVG area (filled by renderer.js) ─────────────────────── */
-.z-svg-area {
-  flex: 1;
-  min-height: 110px;
-  overflow: hidden;
-}
-
-.z-svg-area svg {
+/* ─── The slate board ─────────────────────────────────────────── */
+.board svg {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
+  border: 10px solid var(--wood);
+  border-bottom-color: var(--wood-dark);
+  border-right-color: var(--wood-dark);
+  border-radius: 14px;
+  background:
+    radial-gradient(ellipse at 30% 25%, rgba(255,255,255,0.045) 0%, transparent 55%),
+    radial-gradient(ellipse at 75% 70%, rgba(255,255,255,0.03) 0%, transparent 50%),
+    linear-gradient(160deg, var(--slate) 0%, var(--slate-deep) 100%);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
 }
 
-/* ─── Total row ───────────────────────────────────────────────── */
-.panel-total-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: 8px;
-  border-top: 1px solid rgba(224, 80, 80, 0.45);
+.board-frame {
+  fill: none;
+  stroke: rgba(216, 74, 67, 0.35);
+  stroke-width: 2.5;
 }
 
-.total-label {
-  font-size: 0.8rem;
-  color: var(--chalk-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.board-divider {
+  stroke: var(--paint-red);
+  stroke-width: 3.5;
+  stroke-linecap: round;
+  opacity: 0.85;
 }
 
-.total-value {
-  font-size: 1.4rem;
+.z-line {
+  stroke: var(--paint-red);
+  stroke-width: 4;
+  stroke-linecap: round;
+  opacity: 0.85;
+}
+
+.z-diag {
+  stroke-width: 3;
+  opacity: 0.7;
+}
+
+.line-label {
+  fill: var(--paint-red-dim);
+  font-family: var(--font-chalk);
+  font-size: 15px;
+}
+
+.mark {
+  stroke: var(--chalk);
+  opacity: 0.92;
+}
+
+.team-name {
+  fill: var(--chalk);
+  font-family: var(--font-chalk);
+  font-size: 27px;
+}
+
+.team-total {
+  fill: var(--chalk);
+  font-family: var(--font-chalk);
+  font-size: 46px;
   font-weight: 700;
-  letter-spacing: 0.04em;
-  text-shadow: 0 0 10px rgba(240,237,224,0.4);
 }
 
-/* ─── Z wrapper — contains SVG guide lines + tally entries ───── */
-.z-wrapper {
-  position: relative;
-  flex: 1;
-  min-height: 110px;
-  overflow-y: auto;
+.rest-num {
+  fill: var(--chalk);
+  font-family: var(--font-chalk);
+  font-size: 28px;
 }
 
-.z-lines {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
+.win-glow {
+  fill: rgba(255, 215, 90, 0.09);
+  stroke: var(--winner-glow);
+  stroke-width: 2.5;
+  animation: glowPulse 1.6s ease-in-out infinite alternate;
 }
-/* ─── Score input area ────────────────────────────────────────── */
+
+@keyframes glowPulse {
+  from { stroke-opacity: 0.35; }
+  to   { stroke-opacity: 0.9; }
+}
+
+/* ─── Score input ─────────────────────────────────────────────── */
 .score-input-area {
-  background: var(--input-bg);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius);
-  padding: 14px;
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.score-input-area.disabled {
-  opacity: 0.55;
-  pointer-events: none;
+.score-input-area.disabled .btn-team,
+.score-input-area.disabled .btn-chip,
+.score-input-area.disabled #input-points,
+.score-input-area.disabled #btn-add {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
-/* ─── Team toggle row ─────────────────────────────────────────── */
+.error-msg {
+  min-height: 1.2em;
+  font-size: 0.85rem;
+  color: #ff9c9c;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.error-msg.visible {
+  opacity: 1;
+}
+
 .team-toggle-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
 }
 
-.btn-team {
-  flex: 1;
-  padding: 10px 8px;
-  background: var(--input-bg);
+.btn {
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--chalk);
+  background: var(--btn-secondary);
   border: 1px solid var(--input-border);
   border-radius: var(--radius);
-  color: var(--chalk-dim);
-  font-size: 0.95rem;
-  font-weight: 600;
+  padding: 13px 14px;
   cursor: pointer;
-  transition: background 0.18s, color 0.18s, border-color 0.18s;
-  letter-spacing: 0.04em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.btn-team.is-active {
-  background: var(--btn-primary);
-  color: #fff;
-  border-color: var(--btn-primary-h);
-}
-
-.btn-team:hover:not(.is-active) {
-  background: rgba(255,255,255,0.06);
-  color: var(--chalk-white);
-}
-
-/* ─── Mark buttons (+100 / +50 / +20) ────────────────────────── */
-.mark-row {
-  display: flex;
-  gap: 8px;
-}
-
-.btn-mark {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  padding: 12px 6px;
-  background: var(--slate-surface);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background 0.18s, transform 0.1s, border-color 0.18s;
-}
-
-.btn-mark:hover {
-  background: rgba(255,255,255,0.07);
-  border-color: rgba(240,237,224,0.3);
-}
-
-.btn-mark:active {
-  transform: scale(0.95);
-  background: rgba(255,255,255,0.12);
-}
-
-.btn-mark:focus-visible {
-  outline: 2px solid var(--chalk-white);
-  outline-offset: 2px;
-}
-
-.mark-pts {
-  font-size: 1.3rem;
-  font-weight: 700;
-  color: var(--chalk-white);
-  text-shadow: 0 0 8px rgba(240,237,224,0.3);
-  letter-spacing: 0.04em;
-}
-
-.mark-lbl {
-  font-size: 0.7rem;
-  color: var(--chalk-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-}
-
-/* ─── Buttons ─────────────────────────────────────────────────── */
-.btn {
-  padding: 10px 18px;
-  border: none;
-  border-radius: var(--radius);
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.18s, transform 0.1s;
+  transition: background 0.15s, transform 0.1s, border-color 0.15s;
   white-space: nowrap;
 }
 
@@ -388,95 +261,98 @@ body {
 }
 
 .btn:focus-visible {
-  outline: 2px solid var(--chalk-white);
+  outline: 3px solid var(--winner-glow);
   outline-offset: 2px;
+}
+
+.btn-icon {
+  padding: 8px 12px;
+  font-size: 1.1rem;
+}
+
+.btn-team {
+  background: var(--input-bg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.btn-team.is-active {
+  background: var(--btn-primary);
+  border-color: var(--btn-primary-h);
+}
+
+.entry-row {
+  display: flex;
+  gap: 8px;
+}
+
+#input-points {
+  flex: 1;
+  min-width: 0;
+  padding: 12px;
+  font-size: 1.15rem;
+  background: var(--input-bg);
+  color: var(--chalk);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius);
 }
 
 .btn-primary {
   background: var(--btn-primary);
-  color: #fff;
-  flex-shrink: 0;
 }
 
 .btn-primary:hover {
   background: var(--btn-primary-h);
 }
 
-.btn-secondary {
-  background: var(--btn-secondary);
-  color: var(--chalk-white);
+.chip-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
 }
 
-.btn-secondary:hover {
-  background: #4a7a6a;
+.btn-chip {
+  padding: 11px 6px;
+  background: var(--input-bg);
+}
+
+.btn-chip:hover {
+  background: var(--btn-secondary);
+}
+
+.action-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .btn-danger {
   background: var(--btn-danger);
-  color: var(--chalk-white);
 }
 
 .btn-danger:hover {
   background: var(--btn-danger-h);
 }
 
-.btn-icon {
-  background: transparent;
-  border: 1px solid var(--input-border);
-  color: var(--chalk-white);
-  padding: 6px 12px;
-  font-size: 1.1rem;
-}
-
-.btn-icon:hover {
-  background: rgba(255,255,255,0.08);
-}
-
-/* ─── Action row ──────────────────────────────────────────────── */
-.action-row {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-}
-
-/* ─── Error message ───────────────────────────────────────────── */
-.error-msg {
-  min-height: 1.2em;
-  font-size: 0.85rem;
-  color: #ff8080;
-  opacity: 0;
-  transition: opacity 0.25s;
-  text-align: center;
-}
-
-.error-msg.visible {
-  opacity: 1;
-}
-
 /* ─── Win overlay ─────────────────────────────────────────────── */
 #win-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(10, 25, 10, 0.88);
-  display: flex;
+  z-index: 50;
+  display: none;
   align-items: center;
   justify-content: center;
-  z-index: 100;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.4s ease;
-  backdrop-filter: blur(3px);
+  background: rgba(10, 14, 12, 0.82);
+  cursor: pointer;
 }
 
 #win-overlay.active {
-  opacity: 1;
-  pointer-events: all;
+  display: flex;
 }
 
 .win-content {
   text-align: center;
-  animation: winPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation: winPop 0.45s ease-out;
 }
 
 @keyframes winPop {
@@ -486,8 +362,7 @@ body {
 
 .win-icon {
   font-size: 4rem;
-  margin-bottom: 12px;
-  animation: winSpin 0.8s ease-out;
+  animation: winSpin 0.6s ease-out;
 }
 
 @keyframes winSpin {
@@ -496,72 +371,74 @@ body {
 }
 
 #win-overlay h2 {
-  font-size: 2.8rem;
+  font-family: var(--font-chalk);
+  font-size: 2.2rem;
   color: var(--winner-glow);
-  text-shadow: 0 0 24px rgba(255,215,0,0.7);
-  margin-bottom: 10px;
-  letter-spacing: 0.1em;
+  text-shadow: 0 0 18px rgba(255, 215, 90, 0.6);
 }
 
 .win-team {
-  font-size: 1.8rem;
-  color: var(--chalk-white);
-  text-shadow: 0 0 16px rgba(240,237,224,0.6);
-  margin-bottom: 16px;
+  font-family: var(--font-chalk);
+  font-size: 1.6rem;
+  margin-top: 6px;
 }
 
 .win-hint {
-  font-size: 0.8rem;
-  color: var(--chalk-dim);
-  opacity: 0.7;
   margin-top: 18px;
-}
-
-/* ─── Chalk dust particles ────────────────────────────────────── */
-.chalk-particles {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
+  font-size: 0.85rem;
+  color: var(--chalk-dim);
 }
 
 .chalk-particles span {
   position: absolute;
-  display: block;
-  width: 6px;
-  height: 6px;
-  background: rgba(240, 237, 224, 0.6);
+  background: var(--chalk);
   border-radius: 50%;
-  animation: float 3s ease-in-out infinite;
+  opacity: 0.7;
+  animation: float 2.6s ease-in infinite;
 }
 
-.chalk-particles span:nth-child(1)  { left: 10%; top: 20%; animation-delay: 0s;    animation-duration: 2.8s; width: 4px;  height: 4px; }
-.chalk-particles span:nth-child(2)  { left: 25%; top: 60%; animation-delay: 0.4s;  animation-duration: 3.2s; }
-.chalk-particles span:nth-child(3)  { left: 45%; top: 15%; animation-delay: 0.8s;  animation-duration: 2.5s; width: 8px;  height: 8px; }
-.chalk-particles span:nth-child(4)  { left: 65%; top: 70%; animation-delay: 1.2s;  animation-duration: 3.6s; width: 5px;  height: 5px; }
-.chalk-particles span:nth-child(5)  { left: 80%; top: 30%; animation-delay: 0.2s;  animation-duration: 2.9s; }
-.chalk-particles span:nth-child(6)  { left: 90%; top: 80%; animation-delay: 1.6s;  animation-duration: 3.4s; width: 3px;  height: 3px; }
-.chalk-particles span:nth-child(7)  { left: 55%; top: 45%; animation-delay: 0.6s;  animation-duration: 2.6s; width: 7px;  height: 7px; }
-.chalk-particles span:nth-child(8)  { left: 35%; top: 85%; animation-delay: 1.0s;  animation-duration: 3.0s; }
-.chalk-particles span:nth-child(9)  { left: 72%; top: 10%; animation-delay: 1.4s;  animation-duration: 2.7s; width: 5px;  height: 5px; }
+.chalk-particles span:nth-child(1)  { left: 12%; top: 68%; animation-delay: 0s;    width: 6px; height: 6px; }
+.chalk-particles span:nth-child(2)  { left: 28%; top: 78%; animation-delay: 0.4s;  width: 4px; height: 4px; }
+.chalk-particles span:nth-child(3)  { left: 44%; top: 72%; animation-delay: 0.8s;  width: 7px; height: 7px; }
+.chalk-particles span:nth-child(4)  { left: 60%; top: 80%; animation-delay: 1.2s;  width: 5px; height: 5px; }
+.chalk-particles span:nth-child(5)  { left: 76%; top: 70%; animation-delay: 0.2s;  width: 6px; height: 6px; }
+.chalk-particles span:nth-child(6)  { left: 88%; top: 76%; animation-delay: 0.9s;  width: 4px; height: 4px; }
+.chalk-particles span:nth-child(7)  { left: 20%; top: 16%; animation-delay: 0.6s;  width: 5px; height: 5px; }
+.chalk-particles span:nth-child(8)  { left: 52%; top: 12%; animation-delay: 1.1s;  width: 6px; height: 6px; }
+.chalk-particles span:nth-child(9)  { left: 74%; top: 14%; animation-delay: 1.5s;  width: 5px; height: 5px; }
 
 @keyframes float {
-  0%   { transform: translateY(0)   rotate(0deg);   opacity: 0.8; }
-  50%  { transform: translateY(-30px) rotate(180deg); opacity: 0.4; }
-  100% { transform: translateY(-60px) rotate(360deg); opacity: 0; }
+  0%   { transform: translateY(0)      rotate(0deg);   opacity: 0.8; }
+  50%  { transform: translateY(-30px)  rotate(180deg); opacity: 0.4; }
+  100% { transform: translateY(-60px)  rotate(360deg); opacity: 0; }
+}
+
+/* ─── Motion preferences ──────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .win-glow,
+  .win-content,
+  .win-icon,
+  .chalk-particles span {
+    animation: none;
+  }
 }
 
 /* ─── Responsive ──────────────────────────────────────────────── */
-@media (max-width: 480px) {
-  .app-wrapper { padding: 8px 8px 20px; }
-  .header-title { font-size: 1.3rem; }
-  .panel-team-name { font-size: 0.95rem; }
-  .total-value { font-size: 1.15rem; }
-  .mark-pts { font-size: 1.1rem; }
-  #win-overlay h2 { font-size: 2rem; }
-  .win-team { font-size: 1.3rem; }
-}
+@media (max-width: 380px) {
+  .app-wrapper {
+    padding: 8px 8px 20px;
+  }
 
-@media (min-width: 600px) {
-  .board { min-height: 480px; }
+  .header-title {
+    font-size: 1.2rem;
+  }
+
+  .btn {
+    font-size: 0.9rem;
+    padding: 11px 8px;
+  }
+
+  .board svg {
+    border-width: 7px;
+  }
 }

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -59,14 +59,7 @@
       <!-- Panel A (top) -->
       <section id="panel-a" class="board-panel panel-top" aria-label="Top team">
         <h2 id="team-a-name" class="panel-team-name chalk-text"></h2>
-        <div class="z-wrapper">
-          <svg class="z-lines" viewBox="0 0 400 160" preserveAspectRatio="none" aria-hidden="true">
-            <line x1="0" y1="22" x2="400" y2="22" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
-            <line x1="400" y1="22" x2="0" y2="138" stroke="rgba(224,80,80,0.42)" stroke-width="1.5" stroke-dasharray="10,6"/>
-            <line x1="0" y1="138" x2="400" y2="138" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
-          </svg>
-          <div id="entries-a" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for top team"></div>
-        </div>
+        <div id="z-svg-a" class="z-svg-area" aria-label="Score area for top team" aria-live="polite"></div>
         <div class="panel-total-row">
           <span class="total-label chalk-text">Total:</span>
           <span id="total-a" class="total-value chalk-text">0</span>
@@ -79,14 +72,7 @@
       <!-- Panel B (bottom, rotated 180° — readable from opposite side of table) -->
       <section id="panel-b" class="board-panel panel-bottom" aria-label="Bottom team">
         <h2 id="team-b-name" class="panel-team-name chalk-text"></h2>
-        <div class="z-wrapper">
-          <svg class="z-lines" viewBox="0 0 400 160" preserveAspectRatio="none" aria-hidden="true">
-            <line x1="0" y1="22" x2="400" y2="22" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
-            <line x1="400" y1="22" x2="0" y2="138" stroke="rgba(224,80,80,0.42)" stroke-width="1.5" stroke-dasharray="10,6"/>
-            <line x1="0" y1="138" x2="400" y2="138" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
-          </svg>
-          <div id="entries-b" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for bottom team"></div>
-        </div>
+        <div id="z-svg-b" class="z-svg-area" aria-label="Score area for bottom team" aria-live="polite"></div>
         <div class="panel-total-row">
           <span class="total-label chalk-text">Total:</span>
           <span id="total-b" class="total-value chalk-text">0</span>
@@ -97,26 +83,27 @@
     <!-- Score input area -->
     <div id="score-input-area" class="score-input-area">
       <p id="error-msg" class="error-msg" role="alert" aria-live="assertive"></p>
-      <div class="input-row">
-        <label for="select-team" class="sr-only">Select team</label>
-        <select id="select-team" class="select-team" aria-label="Select team">
-          <option value="A">Team A</option>
-          <option value="B">Team B</option>
-        </select>
 
-        <label for="input-points" class="sr-only">Points</label>
-        <input
-          id="input-points"
-          type="number"
-          class="points-input"
-          placeholder="Punkte…"
-          min="1"
-          max="500"
-          step="1"
-          aria-label="Points to add"
-        />
+      <!-- Team selector -->
+      <div class="team-toggle-row" role="group" aria-label="Select team">
+        <button id="btn-team-a" class="btn btn-team is-active" data-team="A">Team A</button>
+        <button id="btn-team-b" class="btn btn-team" data-team="B">Team B</button>
+      </div>
 
-        <button id="btn-add" class="btn btn-primary" aria-label="Add score">Eintragen</button>
+      <!-- Mark entry: three fixed denominations -->
+      <div class="mark-row" role="group" aria-label="Add mark">
+        <button id="btn-mark-top" class="btn btn-mark" aria-label="Top bar — add 100 points">
+          <span class="mark-pts">+100</span>
+          <span class="mark-lbl">Oben</span>
+        </button>
+        <button id="btn-mark-diag" class="btn btn-mark" aria-label="Diagonal — add 50 points">
+          <span class="mark-pts">+50</span>
+          <span class="mark-lbl">Diagonal</span>
+        </button>
+        <button id="btn-mark-bot" class="btn btn-mark" aria-label="Bottom bar — add 20 points">
+          <span class="mark-pts">+20</span>
+          <span class="mark-lbl">Unten</span>
+        </button>
       </div>
 
       <div class="action-row">

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -37,7 +37,7 @@
           step="50"
           aria-label="Target score"
         />
-        <button id="btn-flip" class="btn btn-icon" title="Flip board" aria-label="Flip board orientation">⇄</button>
+        <button id="btn-flip" class="btn btn-icon" title="Swap teams" aria-label="Swap team positions">↕</button>
       </div>
     </header>
 
@@ -56,30 +56,37 @@
 
     <!-- Scoreboard (Z/Z layout) -->
     <main class="board" role="main" aria-label="Scoreboard">
-      <!-- Panel A (left) -->
-      <section id="panel-a" class="board-panel panel-left" aria-label="Left team">
+      <!-- Panel A (top) -->
+      <section id="panel-a" class="board-panel panel-top" aria-label="Top team">
         <h2 id="team-a-name" class="panel-team-name chalk-text"></h2>
-        <div id="entries-a" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for left team"></div>
+        <div class="z-wrapper">
+          <svg class="z-lines" viewBox="0 0 400 160" preserveAspectRatio="none" aria-hidden="true">
+            <line x1="0" y1="22" x2="400" y2="22" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
+            <line x1="400" y1="22" x2="0" y2="138" stroke="rgba(224,80,80,0.42)" stroke-width="1.5" stroke-dasharray="10,6"/>
+            <line x1="0" y1="138" x2="400" y2="138" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
+          </svg>
+          <div id="entries-a" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for top team"></div>
+        </div>
         <div class="panel-total-row">
           <span class="total-label chalk-text">Total:</span>
           <span id="total-a" class="total-value chalk-text">0</span>
         </div>
       </section>
 
-      <!-- Z/Z diagonal divider -->
-      <div class="board-divider" aria-hidden="true">
-        <svg class="z-divider-svg" viewBox="0 0 60 300" preserveAspectRatio="none">
-          <line x1="30" y1="0" x2="30" y2="300" stroke="rgba(255,100,100,0.55)" stroke-width="2" />
-          <line x1="5" y1="10" x2="55" y2="10" stroke="rgba(255,100,100,0.45)" stroke-width="1.5" />
-          <line x1="5" y1="290" x2="55" y2="290" stroke="rgba(255,100,100,0.45)" stroke-width="1.5" />
-          <line x1="55" y1="10" x2="5" y2="290" stroke="rgba(255,100,100,0.4)" stroke-width="1.5" stroke-dasharray="6,4" />
-        </svg>
-      </div>
+      <!-- Horizontal divider between the two Z shapes -->
+      <div class="board-h-divider" aria-hidden="true"></div>
 
-      <!-- Panel B (right) -->
-      <section id="panel-b" class="board-panel panel-right" aria-label="Right team">
+      <!-- Panel B (bottom, rotated 180° — readable from opposite side of table) -->
+      <section id="panel-b" class="board-panel panel-bottom" aria-label="Bottom team">
         <h2 id="team-b-name" class="panel-team-name chalk-text"></h2>
-        <div id="entries-b" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for right team"></div>
+        <div class="z-wrapper">
+          <svg class="z-lines" viewBox="0 0 400 160" preserveAspectRatio="none" aria-hidden="true">
+            <line x1="0" y1="22" x2="400" y2="22" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
+            <line x1="400" y1="22" x2="0" y2="138" stroke="rgba(224,80,80,0.42)" stroke-width="1.5" stroke-dasharray="10,6"/>
+            <line x1="0" y1="138" x2="400" y2="138" stroke="rgba(224,80,80,0.6)" stroke-width="2"/>
+          </svg>
+          <div id="entries-b" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for bottom team"></div>
+        </div>
         <div class="panel-total-row">
           <span class="total-label chalk-text">Total:</span>
           <span id="total-b" class="total-value chalk-text">0</span>

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jass Scoreboard — Schiefertafel Z/Z</title>
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <!-- Win overlay -->
+  <div id="win-overlay" role="dialog" aria-modal="true" aria-labelledby="win-team-name">
+    <div class="win-content">
+      <div class="win-icon">🏆</div>
+      <h2>Gewonnen!</h2>
+      <p id="win-team-name" class="win-team"></p>
+      <p class="win-hint">Tippe zum Schliessen</p>
+    </div>
+    <div class="chalk-particles" aria-hidden="true">
+      <span></span><span></span><span></span>
+      <span></span><span></span><span></span>
+      <span></span><span></span><span></span>
+    </div>
+  </div>
+
+  <div class="app-wrapper">
+    <!-- Header -->
+    <header class="app-header">
+      <h1 class="header-title">Jass Tafel</h1>
+      <div class="header-settings">
+        <label for="input-target" class="setting-label">Ziel:</label>
+        <input
+          id="input-target"
+          type="number"
+          class="setting-input"
+          min="100"
+          max="10000"
+          step="50"
+          aria-label="Target score"
+        />
+        <button id="btn-flip" class="btn btn-icon" title="Flip board" aria-label="Flip board orientation">⇄</button>
+      </div>
+    </header>
+
+    <!-- Team name editors -->
+    <div class="name-editors">
+      <div class="name-editor-group">
+        <label for="edit-name-a" class="sr-only">Team A name</label>
+        <input id="edit-name-a" type="text" class="team-name-input" maxlength="30" aria-label="Team A name" />
+      </div>
+      <div class="name-editor-divider" aria-hidden="true">vs</div>
+      <div class="name-editor-group">
+        <label for="edit-name-b" class="sr-only">Team B name</label>
+        <input id="edit-name-b" type="text" class="team-name-input" maxlength="30" aria-label="Team B name" />
+      </div>
+    </div>
+
+    <!-- Scoreboard (Z/Z layout) -->
+    <main class="board" role="main" aria-label="Scoreboard">
+      <!-- Panel A (left) -->
+      <section id="panel-a" class="board-panel panel-left" aria-label="Left team">
+        <h2 id="team-a-name" class="panel-team-name chalk-text"></h2>
+        <div id="entries-a" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for left team"></div>
+        <div class="panel-total-row">
+          <span class="total-label chalk-text">Total:</span>
+          <span id="total-a" class="total-value chalk-text">0</span>
+        </div>
+      </section>
+
+      <!-- Z/Z diagonal divider -->
+      <div class="board-divider" aria-hidden="true">
+        <svg class="z-divider-svg" viewBox="0 0 60 300" preserveAspectRatio="none">
+          <line x1="30" y1="0" x2="30" y2="300" stroke="rgba(255,100,100,0.55)" stroke-width="2" />
+          <line x1="5" y1="10" x2="55" y2="10" stroke="rgba(255,100,100,0.45)" stroke-width="1.5" />
+          <line x1="5" y1="290" x2="55" y2="290" stroke="rgba(255,100,100,0.45)" stroke-width="1.5" />
+          <line x1="55" y1="10" x2="5" y2="290" stroke="rgba(255,100,100,0.4)" stroke-width="1.5" stroke-dasharray="6,4" />
+        </svg>
+      </div>
+
+      <!-- Panel B (right) -->
+      <section id="panel-b" class="board-panel panel-right" aria-label="Right team">
+        <h2 id="team-b-name" class="panel-team-name chalk-text"></h2>
+        <div id="entries-b" class="entries-area chalk-text" aria-live="polite" aria-label="Entries for right team"></div>
+        <div class="panel-total-row">
+          <span class="total-label chalk-text">Total:</span>
+          <span id="total-b" class="total-value chalk-text">0</span>
+        </div>
+      </section>
+    </main>
+
+    <!-- Score input area -->
+    <div id="score-input-area" class="score-input-area">
+      <p id="error-msg" class="error-msg" role="alert" aria-live="assertive"></p>
+      <div class="input-row">
+        <label for="select-team" class="sr-only">Select team</label>
+        <select id="select-team" class="select-team" aria-label="Select team">
+          <option value="A">Team A</option>
+          <option value="B">Team B</option>
+        </select>
+
+        <label for="input-points" class="sr-only">Points</label>
+        <input
+          id="input-points"
+          type="number"
+          class="points-input"
+          placeholder="Punkte…"
+          min="1"
+          max="500"
+          step="1"
+          aria-label="Points to add"
+        />
+
+        <button id="btn-add" class="btn btn-primary" aria-label="Add score">Eintragen</button>
+      </div>
+
+      <div class="action-row">
+        <button id="btn-undo" class="btn btn-secondary" aria-label="Undo last entry">↩ Rückgängig</button>
+        <button id="btn-reset" class="btn btn-danger" aria-label="Reset game">🔄 Neu</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="js/app.js"></script>
+</body>
+</html>

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Jass Scoreboard — Schiefertafel Z/Z</title>
+  <title>Jass Tafel — Schiefertafel Z/Z</title>
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
@@ -35,80 +35,60 @@
           min="100"
           max="10000"
           step="50"
-          aria-label="Target score"
+          aria-label="Zielpunktzahl"
         />
-        <button id="btn-flip" class="btn btn-icon" title="Swap teams" aria-label="Swap team positions">↕</button>
+        <button id="btn-flip" class="btn btn-icon" title="Tafel drehen" aria-label="Tafel drehen — Teamseiten tauschen">⇅</button>
       </div>
     </header>
 
     <!-- Team name editors -->
     <div class="name-editors">
-      <div class="name-editor-group">
-        <label for="edit-name-a" class="sr-only">Team A name</label>
-        <input id="edit-name-a" type="text" class="team-name-input" maxlength="30" aria-label="Team A name" />
-      </div>
-      <div class="name-editor-divider" aria-hidden="true">vs</div>
-      <div class="name-editor-group">
-        <label for="edit-name-b" class="sr-only">Team B name</label>
-        <input id="edit-name-b" type="text" class="team-name-input" maxlength="30" aria-label="Team B name" />
-      </div>
+      <label for="edit-name-a" class="sr-only">Name Team A</label>
+      <input id="edit-name-a" type="text" class="team-name-input" maxlength="30" aria-label="Name Team A" />
+      <span class="name-editor-divider" aria-hidden="true">vs</span>
+      <label for="edit-name-b" class="sr-only">Name Team B</label>
+      <input id="edit-name-b" type="text" class="team-name-input" maxlength="30" aria-label="Name Team B" />
     </div>
 
-    <!-- Scoreboard (Z/Z layout) -->
-    <main class="board" role="main" aria-label="Scoreboard">
-      <!-- Panel A (top) -->
-      <section id="panel-a" class="board-panel panel-top" aria-label="Top team">
-        <h2 id="team-a-name" class="panel-team-name chalk-text"></h2>
-        <div id="z-svg-a" class="z-svg-area" aria-label="Score area for top team" aria-live="polite"></div>
-        <div class="panel-total-row">
-          <span class="total-label chalk-text">Total:</span>
-          <span id="total-a" class="total-value chalk-text">0</span>
-        </div>
-      </section>
+    <!-- The slate: one SVG scene with both Z's, rendered by renderer.js -->
+    <main id="board" class="board" role="main" aria-label="Jasstafel"></main>
 
-      <!-- Horizontal divider between the two Z shapes -->
-      <div class="board-h-divider" aria-hidden="true"></div>
+    <!-- Screen-reader live status -->
+    <div id="sr-status" class="sr-only" aria-live="polite"></div>
 
-      <!-- Panel B (bottom, rotated 180° — readable from opposite side of table) -->
-      <section id="panel-b" class="board-panel panel-bottom" aria-label="Bottom team">
-        <h2 id="team-b-name" class="panel-team-name chalk-text"></h2>
-        <div id="z-svg-b" class="z-svg-area" aria-label="Score area for bottom team" aria-live="polite"></div>
-        <div class="panel-total-row">
-          <span class="total-label chalk-text">Total:</span>
-          <span id="total-b" class="total-value chalk-text">0</span>
-        </div>
-      </section>
-    </main>
-
-    <!-- Score input area -->
+    <!-- Score input -->
     <div id="score-input-area" class="score-input-area">
       <p id="error-msg" class="error-msg" role="alert" aria-live="assertive"></p>
 
-      <!-- Team selector -->
-      <div class="team-toggle-row" role="group" aria-label="Select team">
+      <div class="team-toggle-row" role="group" aria-label="Team wählen">
         <button id="btn-team-a" class="btn btn-team is-active" data-team="A">Team A</button>
         <button id="btn-team-b" class="btn btn-team" data-team="B">Team B</button>
       </div>
 
-      <!-- Mark entry: three fixed denominations -->
-      <div class="mark-row" role="group" aria-label="Add mark">
-        <button id="btn-mark-top" class="btn btn-mark" aria-label="Top bar — add 100 points">
-          <span class="mark-pts">+100</span>
-          <span class="mark-lbl">Oben</span>
-        </button>
-        <button id="btn-mark-diag" class="btn btn-mark" aria-label="Diagonal — add 50 points">
-          <span class="mark-pts">+50</span>
-          <span class="mark-lbl">Diagonal</span>
-        </button>
-        <button id="btn-mark-bot" class="btn btn-mark" aria-label="Bottom bar — add 20 points">
-          <span class="mark-pts">+20</span>
-          <span class="mark-lbl">Unten</span>
-        </button>
+      <div class="entry-row">
+        <label for="input-points" class="sr-only">Punkte</label>
+        <input
+          id="input-points"
+          type="number"
+          inputmode="numeric"
+          min="1"
+          max="500"
+          placeholder="Punkte"
+          aria-label="Punkte eingeben (1 bis 500)"
+        />
+        <button id="btn-add" class="btn btn-primary">Eintragen</button>
+      </div>
+
+      <div class="chip-row" role="group" aria-label="Schnelleingabe">
+        <button class="btn btn-chip" data-add="20">+20</button>
+        <button class="btn btn-chip" data-add="50">+50</button>
+        <button class="btn btn-chip" data-add="100">+100</button>
+        <button class="btn btn-chip" data-add="157">+157</button>
       </div>
 
       <div class="action-row">
-        <button id="btn-undo" class="btn btn-secondary" aria-label="Undo last entry">↩ Rückgängig</button>
-        <button id="btn-reset" class="btn btn-danger" aria-label="Reset game">🔄 Neu</button>
+        <button id="btn-undo" class="btn btn-secondary" aria-label="Letzten Eintrag rückgängig machen">↩ Rückgängig</button>
+        <button id="btn-reset" class="btn btn-danger" aria-label="Spiel zurücksetzen">🔄 Neu</button>
       </div>
     </div>
   </div>

--- a/jass-scoreboard/js/app.js
+++ b/jass-scoreboard/js/app.js
@@ -1,0 +1,35 @@
+// app.js — application bootstrap
+
+import { getState, setState } from "./state.js";
+import { loadState } from "./storage.js";
+import { recalcTotals, checkWinner } from "./scoring.js";
+import { render } from "./renderer.js";
+import { bindEvents, initInputValues } from "./ui.js";
+
+function bootstrap() {
+  // Attempt to restore persisted state
+  const saved = loadState();
+  if (saved) {
+    // Merge saved data into state carefully
+    const current = getState();
+    const restored = {
+      teams: saved.teams || current.teams,
+      entries: saved.entries || [],
+      totals: { A: 0, B: 0 },
+      targetScore:
+        typeof saved.targetScore === "number" ? saved.targetScore : current.targetScore,
+      flipped: typeof saved.flipped === "boolean" ? saved.flipped : false,
+      winner: saved.winner || null,
+      gameFinished: typeof saved.gameFinished === "boolean" ? saved.gameFinished : false
+    };
+    setState(restored);
+    recalcTotals();
+    checkWinner();
+  }
+
+  initInputValues();
+  bindEvents();
+  render();
+}
+
+document.addEventListener("DOMContentLoaded", bootstrap);

--- a/jass-scoreboard/js/app.js
+++ b/jass-scoreboard/js/app.js
@@ -1,34 +1,13 @@
 // app.js — application bootstrap
 
-import { getState, setState } from "./state.js";
+import { initState } from "./state.js";
 import { loadState } from "./storage.js";
-import { recalcTotals, checkWinner } from "./scoring.js";
+import { bindUI } from "./ui.js";
 import { render } from "./renderer.js";
-import { bindEvents, initInputValues } from "./ui.js";
 
 function bootstrap() {
-  // Attempt to restore persisted state
-  const saved = loadState();
-  if (saved) {
-    // Merge saved data into state carefully
-    const current = getState();
-    const restored = {
-      teams: saved.teams || current.teams,
-      entries: saved.entries || [],
-      totals: { A: 0, B: 0 },
-      targetScore:
-        typeof saved.targetScore === "number" ? saved.targetScore : current.targetScore,
-      flipped: typeof saved.flipped === "boolean" ? saved.flipped : false,
-      winner: saved.winner || null,
-      gameFinished: typeof saved.gameFinished === "boolean" ? saved.gameFinished : false
-    };
-    setState(restored);
-    recalcTotals();
-    checkWinner();
-  }
-
-  initInputValues();
-  bindEvents();
+  initState(loadState());
+  bindUI();
   render();
 }
 

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -39,28 +39,28 @@ function buildEntriesHTML(teamId) {
 function render() {
   const state = getState();
 
-  const [leftTeam, rightTeam] = state.flipped
+  const [topTeam, bottomTeam] = state.flipped
     ? [state.teams[1], state.teams[0]]
     : [state.teams[0], state.teams[1]];
 
   // Team name headers
-  document.getElementById("team-a-name").textContent = leftTeam.name;
-  document.getElementById("team-b-name").textContent = rightTeam.name;
+  document.getElementById("team-a-name").textContent = topTeam.name;
+  document.getElementById("team-b-name").textContent = bottomTeam.name;
 
   // Entries (tally marks)
-  document.getElementById("entries-a").innerHTML = buildEntriesHTML(leftTeam.id);
-  document.getElementById("entries-b").innerHTML = buildEntriesHTML(rightTeam.id);
+  document.getElementById("entries-a").innerHTML = buildEntriesHTML(topTeam.id);
+  document.getElementById("entries-b").innerHTML = buildEntriesHTML(bottomTeam.id);
 
   // Totals
-  document.getElementById("total-a").textContent = state.totals[leftTeam.id] || 0;
-  document.getElementById("total-b").textContent = state.totals[rightTeam.id] || 0;
+  document.getElementById("total-a").textContent = state.totals[topTeam.id] || 0;
+  document.getElementById("total-b").textContent = state.totals[bottomTeam.id] || 0;
 
   // Target score display
   const targetEl = document.getElementById("target-score-display");
   if (targetEl) targetEl.textContent = state.targetScore;
 
   // Win state
-  renderWinState(leftTeam, rightTeam);
+  renderWinState(topTeam, bottomTeam);
 
   // Update team select options to reflect current names
   const teamSelect = document.getElementById("select-team");
@@ -89,21 +89,21 @@ function render() {
     panelB.classList.remove("winner-panel");
     if (state.gameFinished && state.winner) {
       const winnerId = state.winner;
-      const winnerIsLeft = leftTeam.id === winnerId;
-      if (winnerIsLeft) panelA.classList.add("winner-panel");
+      const winnerIsTop = topTeam.id === winnerId;
+      if (winnerIsTop) panelA.classList.add("winner-panel");
       else panelB.classList.add("winner-panel");
     }
   }
 }
 
-function renderWinState(leftTeam, rightTeam) {
+function renderWinState(topTeam, bottomTeam) {
   const state = getState();
   const overlay = document.getElementById("win-overlay");
   if (!overlay) return;
 
   if (state.gameFinished && state.winner) {
     const winningTeam =
-      state.winner === leftTeam.id ? leftTeam : rightTeam;
+      state.winner === topTeam.id ? topTeam : bottomTeam;
     document.getElementById("win-team-name").textContent = winningTeam.name;
     overlay.classList.add("active");
   } else {

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -1,0 +1,114 @@
+// renderer.js — render board, tallies, totals, win state
+
+import { getState } from "./state.js";
+
+/**
+ * Converts a point value into tally mark strings.
+ * Groups of 5 become "||||\" and remainders are "|".
+ */
+function renderTallies(points) {
+  const groups = Math.floor(points / 5);
+  const remainder = points % 5;
+  let result = "";
+  for (let i = 0; i < groups; i++) {
+    result += "||||\\  ";
+  }
+  for (let i = 0; i < remainder; i++) {
+    result += "| ";
+  }
+  return result.trim();
+}
+
+/**
+ * Build the HTML for one team's entry list.
+ */
+function buildEntriesHTML(teamId) {
+  const state = getState();
+  const teamEntries = state.entries.filter(e => e.teamId === teamId);
+  if (teamEntries.length === 0) {
+    return '<span class="no-entries">—</span>';
+  }
+  return teamEntries
+    .map(e => `<div class="tally-row">${renderTallies(e.points)}</div>`)
+    .join("");
+}
+
+/**
+ * Full render of the scoreboard.
+ */
+function render() {
+  const state = getState();
+
+  const [leftTeam, rightTeam] = state.flipped
+    ? [state.teams[1], state.teams[0]]
+    : [state.teams[0], state.teams[1]];
+
+  // Team name headers
+  document.getElementById("team-a-name").textContent = leftTeam.name;
+  document.getElementById("team-b-name").textContent = rightTeam.name;
+
+  // Entries (tally marks)
+  document.getElementById("entries-a").innerHTML = buildEntriesHTML(leftTeam.id);
+  document.getElementById("entries-b").innerHTML = buildEntriesHTML(rightTeam.id);
+
+  // Totals
+  document.getElementById("total-a").textContent = state.totals[leftTeam.id] || 0;
+  document.getElementById("total-b").textContent = state.totals[rightTeam.id] || 0;
+
+  // Target score display
+  const targetEl = document.getElementById("target-score-display");
+  if (targetEl) targetEl.textContent = state.targetScore;
+
+  // Win state
+  renderWinState(leftTeam, rightTeam);
+
+  // Update team select options to reflect current names
+  const teamSelect = document.getElementById("select-team");
+  if (teamSelect) {
+    for (const opt of teamSelect.options) {
+      const team = state.teams.find(t => t.id === opt.value);
+      if (team) opt.textContent = team.name;
+    }
+  }
+
+  // Input area enable/disable (undo and reset always stay enabled)
+  const inputArea = document.getElementById("score-input-area");
+  if (inputArea) {
+    inputArea.classList.toggle("disabled", state.gameFinished);
+    const inputs = inputArea.querySelectorAll("input, select");
+    inputs.forEach(el => { el.disabled = state.gameFinished; });
+    const addBtn = document.getElementById("btn-add");
+    if (addBtn) addBtn.disabled = state.gameFinished;
+  }
+
+  // Highlight winning panel
+  const panelA = document.getElementById("panel-a");
+  const panelB = document.getElementById("panel-b");
+  if (panelA && panelB) {
+    panelA.classList.remove("winner-panel");
+    panelB.classList.remove("winner-panel");
+    if (state.gameFinished && state.winner) {
+      const winnerId = state.winner;
+      const winnerIsLeft = leftTeam.id === winnerId;
+      if (winnerIsLeft) panelA.classList.add("winner-panel");
+      else panelB.classList.add("winner-panel");
+    }
+  }
+}
+
+function renderWinState(leftTeam, rightTeam) {
+  const state = getState();
+  const overlay = document.getElementById("win-overlay");
+  if (!overlay) return;
+
+  if (state.gameFinished && state.winner) {
+    const winningTeam =
+      state.winner === leftTeam.id ? leftTeam : rightTeam;
+    document.getElementById("win-team-name").textContent = winningTeam.name;
+    overlay.classList.add("active");
+  } else {
+    overlay.classList.remove("active");
+  }
+}
+
+export { render, renderTallies };

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -2,35 +2,88 @@
 
 import { getState } from "./state.js";
 
+// ── SVG Z geometry constants ──────────────────────────────────────
+const Z_W  = 400;   // viewBox width
+const Z_H  = 170;   // viewBox height
+const X_L  = 12;    // left x bound
+const X_R  = 388;   // right x bound
+const TOP_Y = 42;   // top bar y
+const BOT_Y = 128;  // bottom bar y
+// Diagonal: (X_R, TOP_Y) → (X_L, BOT_Y)
+
+// Mark spacing limits (SVG viewBox units)
+const MIN_SPACING = 6;
+const MAX_SPACING = 13;
+const DIAG_MARGIN = 14;  // gap to leave at each end of the diagonal
+
 /**
- * Converts a point value into tally mark strings.
- * Groups of 5 become "||||\" and remainders are "|".
+ * Build perpendicular tick marks along the top or bottom horizontal bar.
  */
-function renderTallies(points) {
-  const groups = Math.floor(points / 5);
-  const remainder = points % 5;
-  let result = "";
-  for (let i = 0; i < groups; i++) {
-    result += "||||\\  ";
+function hMarks(count, y) {
+  if (!count) return "";
+  const usable = X_R - X_L - 16;                               // ~360 px
+  const spacing = Math.max(MIN_SPACING, Math.min(MAX_SPACING, count > 1 ? usable / (count - 1) : usable));
+  const totalSpan = spacing * (count - 1);
+  const startX = X_L + 8 + (usable - totalSpan) / 2;
+
+  let out = "";
+  for (let i = 0; i < count; i++) {
+    const x = +(startX + i * spacing).toFixed(1);
+    out += `<line x1="${x}" y1="${y - 11}" x2="${x}" y2="${y + 11}" stroke="rgba(240,237,224,0.92)" stroke-width="2" stroke-linecap="round"/>`;
   }
-  for (let i = 0; i < remainder; i++) {
-    result += "| ";
-  }
-  return result.trim();
+  return out;
 }
 
 /**
- * Build the HTML for one team's entry list.
+ * Build perpendicular tick marks along the diagonal of the Z.
+ * Marks are drawn as short vertical lines since preserveAspectRatio="none"
+ * would skew true perpendiculars; vertical ticks look authentic on a chalk board.
  */
-function buildEntriesHTML(teamId) {
-  const state = getState();
-  const teamEntries = state.entries.filter(e => e.teamId === teamId);
-  if (teamEntries.length === 0) {
-    return '<span class="no-entries">—</span>';
+function diagMarks(count) {
+  if (!count) return "";
+  const dx = X_L - X_R;         // -376
+  const dy = BOT_Y - TOP_Y;     //  86
+  const len = Math.sqrt(dx * dx + dy * dy);
+  const ux = dx / len;  const uy = dy / len;  // unit along diagonal
+
+  const usable = len - 2 * DIAG_MARGIN;
+  const spacing = Math.max(MIN_SPACING, Math.min(MAX_SPACING, count > 1 ? usable / (count - 1) : usable));
+  const totalSpan = spacing * (count - 1);
+  const tStart = DIAG_MARGIN + (usable - totalSpan) / 2;
+
+  let out = "";
+  for (let i = 0; i < count; i++) {
+    const t  = tStart + i * spacing;
+    const cx = +(X_R + ux * t).toFixed(1);
+    const cy = +(TOP_Y + uy * t).toFixed(1);
+    // Vertical tick crossing the diagonal line
+    out += `<line x1="${cx}" y1="${+(cy - 13).toFixed(1)}" x2="${cx}" y2="${+(cy + 13).toFixed(1)}" stroke="rgba(240,237,224,0.92)" stroke-width="2" stroke-linecap="round"/>`;
   }
-  return teamEntries
-    .map(e => `<div class="tally-row">${renderTallies(e.points)}</div>`)
-    .join("");
+  return out;
+}
+
+/**
+ * Build the complete SVG Z shape with marks on lines for one team.
+ */
+function buildZsvg(teamId) {
+  const state = getState();
+  const entries = state.entries.filter(e => e.teamId === teamId);
+
+  // Count marks per bar (support legacy entries that only have points/no barType)
+  const topN  = entries.filter(e => e.barType === "top").length;
+  const diagN = entries.filter(e => e.barType === "diagonal").length;
+  const botN  = entries.filter(e => e.barType === "bottom").length;
+
+  return `<svg viewBox="0 0 ${Z_W} ${Z_H}" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" preserveAspectRatio="none" aria-hidden="true">
+    <!-- Z guide lines -->
+    <line x1="${X_L}" y1="${TOP_Y}" x2="${X_R}" y2="${TOP_Y}" stroke="rgba(224,80,80,0.80)" stroke-width="2.5" stroke-linecap="round"/>
+    <line x1="${X_R}" y1="${TOP_Y}" x2="${X_L}" y2="${BOT_Y}" stroke="rgba(224,80,80,0.52)" stroke-width="1.5" stroke-dasharray="9,6"/>
+    <line x1="${X_L}" y1="${BOT_Y}" x2="${X_R}" y2="${BOT_Y}" stroke="rgba(224,80,80,0.80)" stroke-width="2.5" stroke-linecap="round"/>
+    <!-- Chalk marks on bars -->
+    ${hMarks(topN,  TOP_Y)}
+    ${diagMarks(diagN)}
+    ${hMarks(botN,  BOT_Y)}
+  </svg>`;
 }
 
 /**
@@ -43,13 +96,15 @@ function render() {
     ? [state.teams[1], state.teams[0]]
     : [state.teams[0], state.teams[1]];
 
-  // Team name headers
+  // Team name headers inside panels
   document.getElementById("team-a-name").textContent = topTeam.name;
   document.getElementById("team-b-name").textContent = bottomTeam.name;
 
-  // Entries (tally marks)
-  document.getElementById("entries-a").innerHTML = buildEntriesHTML(topTeam.id);
-  document.getElementById("entries-b").innerHTML = buildEntriesHTML(bottomTeam.id);
+  // SVG Z marks
+  const svgA = document.getElementById("z-svg-a");
+  const svgB = document.getElementById("z-svg-b");
+  if (svgA) svgA.innerHTML = buildZsvg(topTeam.id);
+  if (svgB) svgB.innerHTML = buildZsvg(bottomTeam.id);
 
   // Totals
   document.getElementById("total-a").textContent = state.totals[topTeam.id] || 0;
@@ -59,26 +114,22 @@ function render() {
   const targetEl = document.getElementById("target-score-display");
   if (targetEl) targetEl.textContent = state.targetScore;
 
+  // Update team toggle button labels
+  const btnTeamA = document.getElementById("btn-team-a");
+  const btnTeamB = document.getElementById("btn-team-b");
+  if (btnTeamA) btnTeamA.textContent = state.teams[0].name;
+  if (btnTeamB) btnTeamB.textContent = state.teams[1].name;
+
   // Win state
   renderWinState(topTeam, bottomTeam);
-
-  // Update team select options to reflect current names
-  const teamSelect = document.getElementById("select-team");
-  if (teamSelect) {
-    for (const opt of teamSelect.options) {
-      const team = state.teams.find(t => t.id === opt.value);
-      if (team) opt.textContent = team.name;
-    }
-  }
 
   // Input area enable/disable (undo and reset always stay enabled)
   const inputArea = document.getElementById("score-input-area");
   if (inputArea) {
     inputArea.classList.toggle("disabled", state.gameFinished);
-    const inputs = inputArea.querySelectorAll("input, select");
-    inputs.forEach(el => { el.disabled = state.gameFinished; });
-    const addBtn = document.getElementById("btn-add");
-    if (addBtn) addBtn.disabled = state.gameFinished;
+    inputArea.querySelectorAll(".btn-mark, .btn-team").forEach(el => {
+      el.disabled = state.gameFinished;
+    });
   }
 
   // Highlight winning panel
@@ -88,10 +139,9 @@ function render() {
     panelA.classList.remove("winner-panel");
     panelB.classList.remove("winner-panel");
     if (state.gameFinished && state.winner) {
-      const winnerId = state.winner;
-      const winnerIsTop = topTeam.id === winnerId;
+      const winnerIsTop = topTeam.id === state.winner;
       if (winnerIsTop) panelA.classList.add("winner-panel");
-      else panelB.classList.add("winner-panel");
+      else             panelB.classList.add("winner-panel");
     }
   }
 }
@@ -102,8 +152,7 @@ function renderWinState(topTeam, bottomTeam) {
   if (!overlay) return;
 
   if (state.gameFinished && state.winner) {
-    const winningTeam =
-      state.winner === topTeam.id ? topTeam : bottomTeam;
+    const winningTeam = state.winner === topTeam.id ? topTeam : bottomTeam;
     document.getElementById("win-team-name").textContent = winningTeam.name;
     overlay.classList.add("active");
   } else {
@@ -111,4 +160,4 @@ function renderWinState(topTeam, bottomTeam) {
   }
 }
 
-export { render, renderTallies };
+export { render };

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -1,159 +1,228 @@
-// renderer.js — render board, tallies, totals, win state
+// renderer.js — draws the whole slate as one SVG scene:
+// two chalk Z's (one per team), marks, totals, win state.
+//
+// Readability from both sides of the table:
+// Each Z is drawn point-symmetric about its own centre — the top bar,
+// the diagonal and the bottom bar map exactly onto themselves under a
+// 180° rotation. The far team's half IS rotated 180° (so its name and
+// total face the player across the table), and because of the point
+// symmetry both Z shapes still read as a proper "Z" — never as an
+// "S" — no matter which side of the table you look from.
 
 import { getState } from "./state.js";
+import { decompose } from "./scoring.js";
 
-// ── SVG Z geometry constants ──────────────────────────────────────
-const Z_W  = 400;   // viewBox width
-const Z_H  = 170;   // viewBox height
-const X_L  = 12;    // left x bound
-const X_R  = 388;   // right x bound
-const TOP_Y = 42;   // top bar y
-const BOT_Y = 128;  // bottom bar y
-// Diagonal: (X_R, TOP_Y) → (X_L, BOT_Y)
+// ── Board geometry (one half, local coordinates) ─────────────────
+const W = 640;        // board width
+const HH = 460;       // height of one half
+const H = HH * 2;     // full board height
 
-// Mark spacing limits (SVG viewBox units)
-const MIN_SPACING = 6;
-const MAX_SPACING = 13;
-const DIAG_MARGIN = 14;  // gap to leave at each end of the diagonal
+const XL = 64;        // Z left x
+const XR = 576;       // Z right x
+const TOP_Y = 150;    // Z top bar y
+const BOT_Y = 380;    // Z bottom bar y
+// Z centre = ((XL+XR)/2, (TOP_Y+BOT_Y)/2) = (320, 265).
+// rotate180(x, y) → (640−x, 530−y): top bar ↔ bottom bar, the
+// diagonal (XR,TOP_Y)→(XL,BOT_Y) maps onto itself. Point symmetry ✓
+
+function esc(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 /**
- * Build perpendicular tick marks along the top or bottom horizontal bar.
+ * Deterministic PRNG (mulberry32) — chalk jitter must be stable
+ * across re-renders so the marks don't wiggle on every update.
  */
-function hMarks(count, y) {
-  if (!count) return "";
-  const usable = X_R - X_L - 16;                               // ~360 px
-  const spacing = Math.max(MIN_SPACING, Math.min(MAX_SPACING, count > 1 ? usable / (count - 1) : usable));
-  const totalSpan = spacing * (count - 1);
-  const startX = X_L + 8 + (usable - totalSpan) / 2;
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
 
+function chalkLine(rand, x1, y1, x2, y2, width, cls) {
+  const j = () => rand() * 2.8 - 1.4;
+  return `<line class="${cls}" x1="${(x1 + j()).toFixed(1)}" y1="${(y1 + j()).toFixed(1)}" x2="${(x2 + j()).toFixed(1)}" y2="${(y2 + j()).toFixed(1)}" stroke-width="${width}" stroke-linecap="round"/>`;
+}
+
+/**
+ * Hundreds on the top bar, bundled tally-style: four upright strokes
+ * plus a diagonal slash across them for each complete group of five.
+ */
+function hundredMarks(rand, count) {
+  if (!count) return "";
+  const usable = XR - XL - 24;
+  const groups = [];
+  for (let left = count; left > 0; left -= 5) groups.push(Math.min(left, 5));
+  const uprightTotal = groups.reduce((sum, c) => sum + Math.min(c, 4), 0);
+  const GAP = 26;
+  const denom = Math.max(1, uprightTotal - groups.length);
+  const step = Math.max(7, Math.min(19, (usable - (groups.length - 1) * GAP) / denom));
+
+  let x = XL + 12;
   let out = "";
-  for (let i = 0; i < count; i++) {
-    const x = +(startX + i * spacing).toFixed(1);
-    out += `<line x1="${x}" y1="${y - 11}" x2="${x}" y2="${y + 11}" stroke="rgba(240,237,224,0.92)" stroke-width="2" stroke-linecap="round"/>`;
+  for (const cnt of groups) {
+    const uprights = Math.min(cnt, 4);
+    for (let k = 0; k < uprights; k++) {
+      const ux = x + k * step;
+      out += chalkLine(rand, ux, TOP_Y - 17, ux + (rand() * 4 - 2), TOP_Y + 17, 3.2, "mark");
+    }
+    const groupWidth = (uprights - 1) * step;
+    if (cnt === 5) {
+      out += chalkLine(rand, x - step * 0.45, TOP_Y + 16, x + groupWidth + step * 0.45, TOP_Y - 16, 3.2, "mark");
+    }
+    x += groupWidth + GAP;
   }
   return out;
 }
 
 /**
- * Build perpendicular tick marks along the diagonal of the Z.
- * Marks are drawn as short vertical lines since preserveAspectRatio="none"
- * would skew true perpendiculars; vertical ticks look authentic on a chalk board.
+ * Fifties as strokes crossing the diagonal, laid out along it.
  */
-function diagMarks(count) {
+function fiftyMarks(rand, count) {
   if (!count) return "";
-  const dx = X_L - X_R;         // -376
-  const dy = BOT_Y - TOP_Y;     //  86
+  const dx = XL - XR;
+  const dy = BOT_Y - TOP_Y;
   const len = Math.sqrt(dx * dx + dy * dy);
-  const ux = dx / len;  const uy = dy / len;  // unit along diagonal
-
-  const usable = len - 2 * DIAG_MARGIN;
-  const spacing = Math.max(MIN_SPACING, Math.min(MAX_SPACING, count > 1 ? usable / (count - 1) : usable));
-  const totalSpan = spacing * (count - 1);
-  const tStart = DIAG_MARGIN + (usable - totalSpan) / 2;
+  const ux = dx / len;
+  const uy = dy / len;
+  const px = -uy; // perpendicular unit vector
+  const py = ux;
 
   let out = "";
   for (let i = 0; i < count; i++) {
-    const t  = tStart + i * spacing;
-    const cx = +(X_R + ux * t).toFixed(1);
-    const cy = +(TOP_Y + uy * t).toFixed(1);
-    // Vertical tick crossing the diagonal line
-    out += `<line x1="${cx}" y1="${+(cy - 13).toFixed(1)}" x2="${cx}" y2="${+(cy + 13).toFixed(1)}" stroke="rgba(240,237,224,0.92)" stroke-width="2" stroke-linecap="round"/>`;
+    const t = len * Math.min(0.85, 0.3 + i * 0.11);
+    const cx = XR + ux * t;
+    const cy = TOP_Y + uy * t;
+    out += chalkLine(rand, cx - px * 18, cy - py * 18, cx + px * 18, cy + py * 18, 3.2, "mark");
   }
   return out;
 }
 
 /**
- * Build the complete SVG Z shape with marks on lines for one team.
+ * Twenties as upright strokes on the bottom bar (at most two appear —
+ * five twenties are auto-exchanged for a hundred by decompose()).
  */
-function buildZsvg(teamId) {
-  const state = getState();
-  const entries = state.entries.filter(e => e.teamId === teamId);
-
-  // Count marks per bar (support legacy entries that only have points/no barType)
-  const topN  = entries.filter(e => e.barType === "top").length;
-  const diagN = entries.filter(e => e.barType === "diagonal").length;
-  const botN  = entries.filter(e => e.barType === "bottom").length;
-
-  return `<svg viewBox="0 0 ${Z_W} ${Z_H}" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" preserveAspectRatio="none" aria-hidden="true">
-    <!-- Z guide lines -->
-    <line x1="${X_L}" y1="${TOP_Y}" x2="${X_R}" y2="${TOP_Y}" stroke="rgba(224,80,80,0.80)" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="${X_R}" y1="${TOP_Y}" x2="${X_L}" y2="${BOT_Y}" stroke="rgba(224,80,80,0.52)" stroke-width="1.5" stroke-dasharray="9,6"/>
-    <line x1="${X_L}" y1="${BOT_Y}" x2="${X_R}" y2="${BOT_Y}" stroke="rgba(224,80,80,0.80)" stroke-width="2.5" stroke-linecap="round"/>
-    <!-- Chalk marks on bars -->
-    ${hMarks(topN,  TOP_Y)}
-    ${diagMarks(diagN)}
-    ${hMarks(botN,  BOT_Y)}
-  </svg>`;
+function twentyMarks(rand, count) {
+  if (!count) return "";
+  const usable = XR - XL - 24;
+  const step = Math.min(22, usable / Math.max(1, count));
+  let out = "";
+  for (let i = 0; i < count; i++) {
+    const x = XL + 12 + i * step;
+    out += chalkLine(rand, x, BOT_Y - 17, x + (rand() * 4 - 2), BOT_Y + 17, 3.2, "mark");
+  }
+  return out;
 }
 
 /**
- * Full render of the scoreboard.
+ * One team's half of the slate, drawn in local coordinates for a
+ * viewer sitting at that half's outer edge.
  */
+function buildHalf(team, total, isWinner, seed) {
+  const rand = mulberry32(seed);
+  const { hundreds, fifties, twenties, remainder } = decompose(total);
+
+  let s = "";
+  if (isWinner) {
+    s += `<rect class="win-glow" x="18" y="14" width="${W - 36}" height="${HH - 28}" rx="14"/>`;
+  }
+
+  // Name + total, facing this half's player
+  s += `<text class="team-name" x="${XL}" y="62">${esc(team.name)}</text>`;
+  s += `<text class="team-total" x="${XR}" y="72" text-anchor="end">${total}</text>`;
+
+  // The Z — red painted guide lines, point-symmetric about (320, 265)
+  s += `<g class="z-lines" filter="url(#chalk-rough)">`;
+  s += `<line class="z-line" x1="${XL}" y1="${TOP_Y}" x2="${XR}" y2="${TOP_Y}"/>`;
+  s += `<line class="z-line z-diag" x1="${XR}" y1="${TOP_Y}" x2="${XL}" y2="${BOT_Y}"/>`;
+  s += `<line class="z-line" x1="${XL}" y1="${BOT_Y}" x2="${XR}" y2="${BOT_Y}"/>`;
+  s += `</g>`;
+
+  // Small value labels at the line ends (face this half's player)
+  s += `<text class="line-label" x="${XL - 12}" y="${TOP_Y + 5}" text-anchor="end">100</text>`;
+  s += `<text class="line-label" x="${XL - 12}" y="${BOT_Y + 5}" text-anchor="end">20</text>`;
+  s += `<text class="line-label" x="${(XL + XR) / 2 + 26}" y="${(TOP_Y + BOT_Y) / 2 + 30}">50</text>`;
+
+  // Chalk marks
+  s += `<g class="marks" filter="url(#chalk-rough)">`;
+  s += hundredMarks(rand, hundreds);
+  s += fiftyMarks(rand, fifties);
+  s += twentyMarks(rand, twenties);
+  s += `</g>`;
+
+  // Remainder below 20 written as a chalk number
+  if (remainder > 0) {
+    s += `<text class="rest-num" x="${XR}" y="${BOT_Y + 56}" text-anchor="end">+ ${remainder}</text>`;
+  }
+
+  return s;
+}
+
 function render() {
   const state = getState();
 
-  const [topTeam, bottomTeam] = state.flipped
-    ? [state.teams[1], state.teams[0]]
-    : [state.teams[0], state.teams[1]];
+  // flipped swaps which team sits at the near (bottom) edge;
+  // the data model itself never changes
+  const farTeam = state.flipped ? state.teams[1] : state.teams[0];
+  const nearTeam = state.flipped ? state.teams[0] : state.teams[1];
 
-  // Team name headers inside panels
-  document.getElementById("team-a-name").textContent = topTeam.name;
-  document.getElementById("team-b-name").textContent = bottomTeam.name;
+  const svg = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jasstafel: ${esc(farTeam.name)} ${state.totals[farTeam.id]} Punkte, ${esc(nearTeam.name)} ${state.totals[nearTeam.id]} Punkte">
+    <defs>
+      <filter id="chalk-rough" x="-5%" y="-5%" width="110%" height="110%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.6" numOctaves="2" result="noise"/>
+        <feDisplacementMap in="SourceGraphic" in2="noise" scale="2.4"/>
+      </filter>
+    </defs>
+    <rect class="board-frame" x="10" y="10" width="${W - 20}" height="${H - 20}" rx="16"/>
+    <g transform="rotate(180 ${W / 2} ${HH / 2})">${buildHalf(farTeam, state.totals[farTeam.id], state.winner === farTeam.id, 11)}</g>
+    <line class="board-divider" x1="26" y1="${HH}" x2="${W - 26}" y2="${HH}"/>
+    <g transform="translate(0 ${HH})">${buildHalf(nearTeam, state.totals[nearTeam.id], state.winner === nearTeam.id, 47)}</g>
+  </svg>`;
 
-  // SVG Z marks
-  const svgA = document.getElementById("z-svg-a");
-  const svgB = document.getElementById("z-svg-b");
-  if (svgA) svgA.innerHTML = buildZsvg(topTeam.id);
-  if (svgB) svgB.innerHTML = buildZsvg(bottomTeam.id);
+  const board = document.getElementById("board");
+  if (board) board.innerHTML = svg;
 
-  // Totals
-  document.getElementById("total-a").textContent = state.totals[topTeam.id] || 0;
-  document.getElementById("total-b").textContent = state.totals[bottomTeam.id] || 0;
-
-  // Target score display
-  const targetEl = document.getElementById("target-score-display");
-  if (targetEl) targetEl.textContent = state.targetScore;
-
-  // Update team toggle button labels
+  // Team toggle labels
   const btnTeamA = document.getElementById("btn-team-a");
   const btnTeamB = document.getElementById("btn-team-b");
   if (btnTeamA) btnTeamA.textContent = state.teams[0].name;
   if (btnTeamB) btnTeamB.textContent = state.teams[1].name;
 
-  // Win state
-  renderWinState(topTeam, bottomTeam);
-
-  // Input area enable/disable (undo and reset always stay enabled)
+  // Disable score entry once the game is finished (undo/reset stay active)
   const inputArea = document.getElementById("score-input-area");
   if (inputArea) {
     inputArea.classList.toggle("disabled", state.gameFinished);
-    inputArea.querySelectorAll(".btn-mark, .btn-team").forEach(el => {
-      el.disabled = state.gameFinished;
-    });
+    inputArea
+      .querySelectorAll(".btn-team, .btn-chip, #input-points, #btn-add")
+      .forEach(el => { el.disabled = state.gameFinished; });
   }
 
-  // Highlight winning panel
-  const panelA = document.getElementById("panel-a");
-  const panelB = document.getElementById("panel-b");
-  if (panelA && panelB) {
-    panelA.classList.remove("winner-panel");
-    panelB.classList.remove("winner-panel");
-    if (state.gameFinished && state.winner) {
-      const winnerIsTop = topTeam.id === state.winner;
-      if (winnerIsTop) panelA.classList.add("winner-panel");
-      else             panelB.classList.add("winner-panel");
-    }
+  // Screen-reader status
+  const sr = document.getElementById("sr-status");
+  if (sr) {
+    sr.textContent =
+      `${state.teams[0].name}: ${state.totals.A} Punkte. ` +
+      `${state.teams[1].name}: ${state.totals.B} Punkte. Ziel: ${state.targetScore}.`;
   }
+
+  renderWinOverlay(state);
 }
 
-function renderWinState(topTeam, bottomTeam) {
-  const state = getState();
+function renderWinOverlay(state) {
   const overlay = document.getElementById("win-overlay");
   if (!overlay) return;
-
-  if (state.gameFinished && state.winner) {
-    const winningTeam = state.winner === topTeam.id ? topTeam : bottomTeam;
-    document.getElementById("win-team-name").textContent = winningTeam.name;
+  if (state.gameFinished && state.winner && !state.winAcknowledged) {
+    const winner = state.teams.find(t => t.id === state.winner);
+    document.getElementById("win-team-name").textContent = winner ? winner.name : "";
     overlay.classList.add("active");
   } else {
     overlay.classList.remove("active");

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -1,0 +1,55 @@
+// scoring.js — add score, calculate totals, check winner
+
+import { getState } from "./state.js";
+
+function addEntry(teamId, points) {
+  const state = getState();
+  if (state.gameFinished) return false;
+
+  const p = parseInt(points, 10);
+  if (isNaN(p) || p <= 0 || p > 500) return false;
+  if (!state.teams.find(t => t.id === teamId)) return false;
+
+  state.entries.push({
+    teamId,
+    points: p,
+    timestamp: Date.now()
+  });
+
+  recalcTotals();
+  checkWinner();
+  return true;
+}
+
+function undoLastEntry() {
+  const state = getState();
+  if (state.entries.length === 0) return false;
+  state.entries.pop();
+  state.winner = null;
+  state.gameFinished = false;
+  recalcTotals();
+  checkWinner();
+  return true;
+}
+
+function recalcTotals() {
+  const state = getState();
+  state.totals = { A: 0, B: 0 };
+  for (const entry of state.entries) {
+    state.totals[entry.teamId] = (state.totals[entry.teamId] || 0) + entry.points;
+  }
+}
+
+function checkWinner() {
+  const state = getState();
+  if (state.gameFinished) return;
+  for (const team of state.teams) {
+    if ((state.totals[team.id] || 0) > state.targetScore) {
+      state.winner = team.id;
+      state.gameFinished = true;
+      return;
+    }
+  }
+}
+
+export { addEntry, undoLastEntry, recalcTotals, checkWinner };

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -2,17 +2,19 @@
 
 import { getState } from "./state.js";
 
-function addEntry(teamId, points) {
+// Each bar type and its point value per mark
+const BAR_VALUES = { top: 100, diagonal: 50, bottom: 20 };
+
+function addEntry(teamId, barType) {
   const state = getState();
   if (state.gameFinished) return false;
-
-  const p = parseInt(points, 10);
-  if (isNaN(p) || p <= 0 || p > 500) return false;
+  if (!BAR_VALUES[barType]) return false;
   if (!state.teams.find(t => t.id === teamId)) return false;
 
   state.entries.push({
     teamId,
-    points: p,
+    barType,
+    value: BAR_VALUES[barType],
     timestamp: Date.now()
   });
 
@@ -36,7 +38,9 @@ function recalcTotals() {
   const state = getState();
   state.totals = { A: 0, B: 0 };
   for (const entry of state.entries) {
-    state.totals[entry.teamId] = (state.totals[entry.teamId] || 0) + entry.points;
+    // Support both new (value) and legacy (points) saved entries
+    const pts = entry.value || entry.points || 0;
+    state.totals[entry.teamId] = (state.totals[entry.teamId] || 0) + pts;
   }
 }
 

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -1,59 +1,53 @@
-// scoring.js — add score, calculate totals, check winner
+// scoring.js — score validation, totals, win check, chalk-mark decomposition
 
-import { getState } from "./state.js";
-
-// Each bar type and its point value per mark
-const BAR_VALUES = { top: 100, diagonal: 50, bottom: 20 };
-
-function addEntry(teamId, barType) {
-  const state = getState();
-  if (state.gameFinished) return false;
-  if (!BAR_VALUES[barType]) return false;
-  if (!state.teams.find(t => t.id === teamId)) return false;
-
-  state.entries.push({
-    teamId,
-    barType,
-    value: BAR_VALUES[barType],
-    timestamp: Date.now()
-  });
-
-  recalcTotals();
-  checkWinner();
-  return true;
+/**
+ * Validate a round score. Returns an error message (German) or null if valid.
+ */
+function validatePoints(value) {
+  if (!Number.isInteger(value)) return "Punkte müssen eine ganze Zahl sein.";
+  if (value < 1) return "Punkte müssen grösser als 0 sein.";
+  if (value > 500) return "Maximal 500 Punkte pro Eintrag.";
+  return null;
 }
 
-function undoLastEntry() {
-  const state = getState();
-  if (state.entries.length === 0) return false;
-  state.entries.pop();
-  state.winner = null;
-  state.gameFinished = false;
-  recalcTotals();
-  checkWinner();
-  return true;
-}
-
-function recalcTotals() {
-  const state = getState();
-  state.totals = { A: 0, B: 0 };
-  for (const entry of state.entries) {
-    // Support both new (value) and legacy (points) saved entries
-    const pts = entry.value || entry.points || 0;
-    state.totals[entry.teamId] = (state.totals[entry.teamId] || 0) + pts;
-  }
-}
-
-function checkWinner() {
-  const state = getState();
-  if (state.gameFinished) return;
-  for (const team of state.teams) {
-    if ((state.totals[team.id] || 0) > state.targetScore) {
-      state.winner = team.id;
-      state.gameFinished = true;
-      return;
+/**
+ * Totals are always derived from the entry list, never edited directly.
+ */
+function computeTotals(entries) {
+  const totals = { A: 0, B: 0 };
+  for (const e of entries) {
+    if (totals[e.teamId] !== undefined && Number.isFinite(e.points)) {
+      totals[e.teamId] += e.points;
     }
   }
+  return totals;
 }
 
-export { addEntry, undoLastEntry, recalcTotals, checkWinner };
+/**
+ * A team wins when its total EXCEEDS the target score (strictly greater).
+ */
+function findWinner(totals, targetScore) {
+  for (const id of ["A", "B"]) {
+    if (totals[id] > targetScore) return id;
+  }
+  return null;
+}
+
+/**
+ * Decompose a running total into classic Schieber chalk notation:
+ * hundreds on the top bar, fifties on the diagonal, twenties on the
+ * bottom bar, remainder written as a number. The board is always kept
+ * in canonical form — five twenties are automatically "exchanged" for
+ * a hundred, exactly like a tidy chalk writer would do.
+ */
+function decompose(total) {
+  const hundreds = Math.floor(total / 100);
+  let rest = total % 100;
+  const fifties = Math.floor(rest / 50);
+  rest %= 50;
+  const twenties = Math.floor(rest / 20);
+  rest %= 20;
+  return { hundreds, fifties, twenties, remainder: rest };
+}
+
+export { validatePoints, computeTotals, findWinner, decompose };

--- a/jass-scoreboard/js/state.js
+++ b/jass-scoreboard/js/state.js
@@ -1,0 +1,63 @@
+// state.js — global state definition and mutations
+
+const DEFAULT_STATE = {
+  teams: [
+    { id: "A", name: "Team A" },
+    { id: "B", name: "Team B" }
+  ],
+  entries: [],
+  totals: {
+    A: 0,
+    B: 0
+  },
+  targetScore: 2500,
+  flipped: false,
+  winner: null,
+  gameFinished: false
+};
+
+let state = JSON.parse(JSON.stringify(DEFAULT_STATE));
+
+function getState() {
+  return state;
+}
+
+function setState(newState) {
+  state = newState;
+}
+
+function resetState() {
+  const preserved = {
+    teams: state.teams.map(t => ({ ...t })),
+    targetScore: state.targetScore,
+    flipped: state.flipped
+  };
+  state = {
+    ...JSON.parse(JSON.stringify(DEFAULT_STATE)),
+    teams: preserved.teams,
+    targetScore: preserved.targetScore,
+    flipped: preserved.flipped
+  };
+}
+
+function setTeamName(teamId, name) {
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > 30) return false;
+  const team = state.teams.find(t => t.id === teamId);
+  if (!team) return false;
+  team.name = trimmed;
+  return true;
+}
+
+function setTargetScore(value) {
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 100 || n > 10000) return false;
+  state.targetScore = n;
+  return true;
+}
+
+function flipBoard() {
+  state.flipped = !state.flipped;
+}
+
+export { getState, setState, resetState, setTeamName, setTargetScore, flipBoard };

--- a/jass-scoreboard/js/state.js
+++ b/jass-scoreboard/js/state.js
@@ -1,63 +1,122 @@
-// state.js — global state definition and mutations
+// state.js — global state definition, mutations, validation
 
-const DEFAULT_STATE = {
-  teams: [
-    { id: "A", name: "Team A" },
-    { id: "B", name: "Team B" }
-  ],
-  entries: [],
-  totals: {
-    A: 0,
-    B: 0
-  },
-  targetScore: 2500,
-  flipped: false,
-  winner: null,
-  gameFinished: false
-};
+import { computeTotals, findWinner, validatePoints } from "./scoring.js";
+import { saveState } from "./storage.js";
 
-let state = JSON.parse(JSON.stringify(DEFAULT_STATE));
+function defaults() {
+  return {
+    teams: [
+      { id: "A", name: "Team A" },
+      { id: "B", name: "Team B" }
+    ],
+    entries: [],
+    totals: { A: 0, B: 0 },
+    targetScore: 2500,
+    flipped: false,
+    winner: null,
+    gameFinished: false,
+    // transient, never persisted: whether the win overlay was dismissed
+    winAcknowledged: false
+  };
+}
+
+let state = defaults();
+
+function recompute() {
+  state.totals = computeTotals(state.entries);
+  state.winner = findWinner(state.totals, state.targetScore);
+  state.gameFinished = state.winner !== null;
+  if (!state.gameFinished) state.winAcknowledged = false;
+}
+
+function initState(saved) {
+  state = defaults();
+  if (saved && typeof saved === "object") {
+    if (Array.isArray(saved.teams)) {
+      for (const team of state.teams) {
+        const savedTeam = saved.teams.find(t => t && t.id === team.id);
+        if (savedTeam && typeof savedTeam.name === "string") {
+          const name = savedTeam.name.trim().slice(0, 30);
+          if (name.length >= 1) team.name = name;
+        }
+      }
+    }
+    if (Array.isArray(saved.entries)) state.entries = saved.entries;
+    const target = Math.round(Number(saved.targetScore));
+    if (Number.isFinite(target) && target >= 100 && target <= 10000) {
+      state.targetScore = target;
+    }
+    state.flipped = saved.flipped === true;
+  }
+  recompute();
+}
 
 function getState() {
   return state;
 }
 
-function setState(newState) {
-  state = newState;
-}
-
-function resetState() {
-  const preserved = {
-    teams: state.teams.map(t => ({ ...t })),
-    targetScore: state.targetScore,
-    flipped: state.flipped
-  };
-  state = {
-    ...JSON.parse(JSON.stringify(DEFAULT_STATE)),
-    teams: preserved.teams,
-    targetScore: preserved.targetScore,
-    flipped: preserved.flipped
-  };
-}
-
 function setTeamName(teamId, name) {
-  const trimmed = name.trim();
+  const trimmed = String(name).trim();
   if (trimmed.length < 1 || trimmed.length > 30) return false;
   const team = state.teams.find(t => t.id === teamId);
   if (!team) return false;
   team.name = trimmed;
+  saveState(state);
   return true;
 }
 
 function setTargetScore(value) {
-  const n = parseInt(value, 10);
-  if (isNaN(n) || n < 100 || n > 10000) return false;
+  const n = Math.round(Number(value));
+  if (!Number.isFinite(n) || n < 100 || n > 10000) return false;
   state.targetScore = n;
+  recompute();
+  saveState(state);
   return true;
 }
 
-function flipBoard() {
-  state.flipped = !state.flipped;
+function addEntry(teamId, points) {
+  if (state.gameFinished) return "Spiel beendet — Rückgängig oder Neu.";
+  if (!state.teams.find(t => t.id === teamId)) return "Ungültiges Team.";
+  const error = validatePoints(points);
+  if (error) return error;
+  state.entries.push({ teamId, points, timestamp: Date.now() });
+  recompute();
+  saveState(state);
+  return null;
 }
 
-export { getState, setState, resetState, setTeamName, setTargetScore, flipBoard };
+function undoEntry() {
+  if (state.entries.length === 0) return false;
+  state.entries.pop();
+  recompute();
+  saveState(state);
+  return true;
+}
+
+function resetGame() {
+  // Clear entries/winner, keep team names, target score and flip state
+  state.entries = [];
+  recompute();
+  saveState(state);
+}
+
+function toggleFlip() {
+  state.flipped = !state.flipped;
+  saveState(state);
+}
+
+function acknowledgeWin() {
+  state.winAcknowledged = true;
+}
+
+export {
+  initState,
+  getState,
+  setTeamName,
+  setTargetScore,
+  addEntry,
+  undoEntry,
+  resetGame,
+  toggleFlip,
+  acknowledgeWin
+};

--- a/jass-scoreboard/js/storage.js
+++ b/jass-scoreboard/js/storage.js
@@ -1,0 +1,41 @@
+// storage.js — localStorage persistence
+
+const STORAGE_KEY = "jassScoreboardState";
+
+function saveState(state) {
+  const toSave = {
+    teams: state.teams,
+    entries: state.entries,
+    targetScore: state.targetScore,
+    flipped: state.flipped,
+    winner: state.winner,
+    gameFinished: state.gameFinished
+  };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toSave));
+  } catch (e) {
+    // storage may be unavailable (e.g. private mode quota)
+    console.warn("Could not save state:", e);
+  }
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (e) {
+    console.warn("Could not load state:", e);
+    return null;
+  }
+}
+
+function clearState() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.warn("Could not clear state:", e);
+  }
+}
+
+export { saveState, loadState, clearState };

--- a/jass-scoreboard/js/storage.js
+++ b/jass-scoreboard/js/storage.js
@@ -1,4 +1,4 @@
-// storage.js — localStorage persistence
+// storage.js — localStorage persistence, serialization, restoration
 
 const STORAGE_KEY = "jassScoreboardState";
 
@@ -14,20 +14,40 @@ function saveState(state) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(toSave));
   } catch (e) {
-    // storage may be unavailable (e.g. private mode quota)
+    // storage may be unavailable (private mode, quota)
     console.warn("Could not save state:", e);
   }
 }
 
+/**
+ * Restore a saved state. Entries from older versions of the app
+ * (which stored {barType, value} instead of {points}) are migrated.
+ */
 function loadState() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw);
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object") return null;
+    if (Array.isArray(data.entries)) {
+      data.entries = data.entries.map(migrateEntry).filter(Boolean);
+    } else {
+      data.entries = [];
+    }
+    return data;
   } catch (e) {
     console.warn("Could not load state:", e);
     return null;
   }
+}
+
+function migrateEntry(entry) {
+  if (!entry || (entry.teamId !== "A" && entry.teamId !== "B")) return null;
+  let points = null;
+  if (Number.isInteger(entry.points) && entry.points >= 1) points = entry.points;
+  else if (Number.isInteger(entry.value) && entry.value >= 1) points = entry.value;
+  if (points === null || points > 500) return null;
+  return { teamId: entry.teamId, points, timestamp: entry.timestamp || 0 };
 }
 
 function clearState() {

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -5,6 +5,8 @@ import { addEntry, undoLastEntry } from "./scoring.js";
 import { render } from "./renderer.js";
 import { saveState } from "./storage.js";
 
+// Currently-active team for mark entry
+let activeTeamId = "A";
 let errorTimeout = null;
 
 function persist() {
@@ -12,18 +14,21 @@ function persist() {
 }
 
 function bindEvents() {
-  // Score entry form
-  const addBtn = document.getElementById("btn-add");
-  if (addBtn) {
-    addBtn.addEventListener("click", handleAddScore);
-  }
+  // Team toggle buttons
+  const btnTeamA = document.getElementById("btn-team-a");
+  const btnTeamB = document.getElementById("btn-team-b");
+  if (btnTeamA) btnTeamA.addEventListener("click", () => setActiveTeam("A"));
+  if (btnTeamB) btnTeamB.addEventListener("click", () => setActiveTeam("B"));
 
-  // Allow pressing Enter in the points input
-  const pointsInput = document.getElementById("input-points");
-  if (pointsInput) {
-    pointsInput.addEventListener("keydown", e => {
-      if (e.key === "Enter") handleAddScore();
-    });
+  // Mark entry buttons (+100 / +50 / +20)
+  const markDefs = [
+    { id: "btn-mark-top",  barType: "top"      },
+    { id: "btn-mark-diag", barType: "diagonal" },
+    { id: "btn-mark-bot",  barType: "bottom"   }
+  ];
+  for (const { id, barType } of markDefs) {
+    const btn = document.getElementById(id);
+    if (btn) btn.addEventListener("click", () => handleMarkAdd(barType));
   }
 
   // Undo button
@@ -44,13 +49,7 @@ function bindEvents() {
         resetState();
         render();
         persist();
-        // Re-enable score input
-        const inputArea = document.getElementById("score-input-area");
-        if (inputArea) {
-          const inputs = inputArea.querySelectorAll("input, button, select");
-          inputs.forEach(el => { el.disabled = false; });
-          inputArea.classList.remove("disabled");
-        }
+        document.getElementById("score-input-area")?.classList.remove("disabled");
         document.getElementById("win-overlay")?.classList.remove("active");
       }
     });
@@ -66,7 +65,7 @@ function bindEvents() {
     });
   }
 
-  // Team name edits (blur to save)
+  // Team name edits (save on blur/change)
   const nameA = document.getElementById("edit-name-a");
   if (nameA) {
     nameA.addEventListener("change", () => {
@@ -94,7 +93,7 @@ function bindEvents() {
       const ok = setTargetScore(targetInput.value);
       if (!ok) {
         targetInput.value = getState().targetScore;
-        showError("Target score must be between 100 and 10000.");
+        showError("Ziel muss zwischen 100 und 10000 liegen.");
       } else {
         render();
         persist();
@@ -102,7 +101,7 @@ function bindEvents() {
     });
   }
 
-  // Close win overlay (click anywhere on it)
+  // Close win overlay on click
   const winOverlay = document.getElementById("win-overlay");
   if (winOverlay) {
     winOverlay.addEventListener("click", () => {
@@ -111,34 +110,19 @@ function bindEvents() {
   }
 }
 
-function handleAddScore() {
+function setActiveTeam(teamId) {
+  activeTeamId = teamId;
+  // Update visual state of toggle buttons
+  document.getElementById("btn-team-a")?.classList.toggle("is-active", teamId === "A");
+  document.getElementById("btn-team-b")?.classList.toggle("is-active", teamId === "B");
+}
+
+function handleMarkAdd(barType) {
   const state = getState();
   if (state.gameFinished) return;
 
-  const teamSelect = document.getElementById("select-team");
-  const pointsInput = document.getElementById("input-points");
-
-  const teamId = teamSelect ? teamSelect.value : null;
-  const pointsRaw = pointsInput ? pointsInput.value : "";
-
-  if (!teamId) {
-    showError("Please select a team.");
-    return;
-  }
-
-  const points = parseInt(pointsRaw, 10);
-  if (isNaN(points) || points <= 0 || points > 500) {
-    showError("Points must be a whole number between 1 and 500.");
-    pointsInput && pointsInput.focus();
-    return;
-  }
-
-  const ok = addEntry(teamId, points);
+  const ok = addEntry(activeTeamId, barType);
   if (ok) {
-    if (pointsInput) {
-      pointsInput.value = "";
-      pointsInput.focus();
-    }
     render();
     persist();
   }
@@ -150,9 +134,7 @@ function showError(msg) {
   errEl.textContent = msg;
   errEl.classList.add("visible");
   clearTimeout(errorTimeout);
-  errorTimeout = setTimeout(() => {
-    errEl.classList.remove("visible");
-  }, 3000);
+  errorTimeout = setTimeout(() => errEl.classList.remove("visible"), 3000);
 }
 
 function initInputValues() {
@@ -164,6 +146,9 @@ function initInputValues() {
   if (nameA) nameA.value = state.teams[0].name;
   if (nameB) nameB.value = state.teams[1].name;
   if (targetInput) targetInput.value = state.targetScore;
+
+  // Sync active team button visual
+  setActiveTeam(activeTeamId);
 }
 
 export { bindEvents, initInputValues };

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -1,0 +1,169 @@
+// ui.js — handle user input, bind event listeners, validate inputs
+
+import { getState, setTeamName, setTargetScore, flipBoard, resetState } from "./state.js";
+import { addEntry, undoLastEntry } from "./scoring.js";
+import { render } from "./renderer.js";
+import { saveState } from "./storage.js";
+
+let errorTimeout = null;
+
+function persist() {
+  saveState(getState());
+}
+
+function bindEvents() {
+  // Score entry form
+  const addBtn = document.getElementById("btn-add");
+  if (addBtn) {
+    addBtn.addEventListener("click", handleAddScore);
+  }
+
+  // Allow pressing Enter in the points input
+  const pointsInput = document.getElementById("input-points");
+  if (pointsInput) {
+    pointsInput.addEventListener("keydown", e => {
+      if (e.key === "Enter") handleAddScore();
+    });
+  }
+
+  // Undo button
+  const undoBtn = document.getElementById("btn-undo");
+  if (undoBtn) {
+    undoBtn.addEventListener("click", () => {
+      undoLastEntry();
+      render();
+      persist();
+    });
+  }
+
+  // Reset button
+  const resetBtn = document.getElementById("btn-reset");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      if (confirm("Reset the game? Team names and target score will be kept.")) {
+        resetState();
+        render();
+        persist();
+        // Re-enable score input
+        const inputArea = document.getElementById("score-input-area");
+        if (inputArea) {
+          const inputs = inputArea.querySelectorAll("input, button, select");
+          inputs.forEach(el => { el.disabled = false; });
+          inputArea.classList.remove("disabled");
+        }
+        document.getElementById("win-overlay")?.classList.remove("active");
+      }
+    });
+  }
+
+  // Flip button
+  const flipBtn = document.getElementById("btn-flip");
+  if (flipBtn) {
+    flipBtn.addEventListener("click", () => {
+      flipBoard();
+      render();
+      persist();
+    });
+  }
+
+  // Team name edits (blur to save)
+  const nameA = document.getElementById("edit-name-a");
+  if (nameA) {
+    nameA.addEventListener("change", () => {
+      const ok = setTeamName("A", nameA.value);
+      if (!ok) nameA.value = getState().teams.find(t => t.id === "A").name;
+      render();
+      persist();
+    });
+  }
+
+  const nameB = document.getElementById("edit-name-b");
+  if (nameB) {
+    nameB.addEventListener("change", () => {
+      const ok = setTeamName("B", nameB.value);
+      if (!ok) nameB.value = getState().teams.find(t => t.id === "B").name;
+      render();
+      persist();
+    });
+  }
+
+  // Target score edit
+  const targetInput = document.getElementById("input-target");
+  if (targetInput) {
+    targetInput.addEventListener("change", () => {
+      const ok = setTargetScore(targetInput.value);
+      if (!ok) {
+        targetInput.value = getState().targetScore;
+        showError("Target score must be between 100 and 10000.");
+      } else {
+        render();
+        persist();
+      }
+    });
+  }
+
+  // Close win overlay (click anywhere on it)
+  const winOverlay = document.getElementById("win-overlay");
+  if (winOverlay) {
+    winOverlay.addEventListener("click", () => {
+      winOverlay.classList.remove("active");
+    });
+  }
+}
+
+function handleAddScore() {
+  const state = getState();
+  if (state.gameFinished) return;
+
+  const teamSelect = document.getElementById("select-team");
+  const pointsInput = document.getElementById("input-points");
+
+  const teamId = teamSelect ? teamSelect.value : null;
+  const pointsRaw = pointsInput ? pointsInput.value : "";
+
+  if (!teamId) {
+    showError("Please select a team.");
+    return;
+  }
+
+  const points = parseInt(pointsRaw, 10);
+  if (isNaN(points) || points <= 0 || points > 500) {
+    showError("Points must be a whole number between 1 and 500.");
+    pointsInput && pointsInput.focus();
+    return;
+  }
+
+  const ok = addEntry(teamId, points);
+  if (ok) {
+    if (pointsInput) {
+      pointsInput.value = "";
+      pointsInput.focus();
+    }
+    render();
+    persist();
+  }
+}
+
+function showError(msg) {
+  const errEl = document.getElementById("error-msg");
+  if (!errEl) return;
+  errEl.textContent = msg;
+  errEl.classList.add("visible");
+  clearTimeout(errorTimeout);
+  errorTimeout = setTimeout(() => {
+    errEl.classList.remove("visible");
+  }, 3000);
+}
+
+function initInputValues() {
+  const state = getState();
+  const nameA = document.getElementById("edit-name-a");
+  const nameB = document.getElementById("edit-name-b");
+  const targetInput = document.getElementById("input-target");
+
+  if (nameA) nameA.value = state.teams[0].name;
+  if (nameB) nameB.value = state.teams[1].name;
+  if (targetInput) targetInput.value = state.targetScore;
+}
+
+export { bindEvents, initInputValues };

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -1,154 +1,135 @@
-// ui.js — handle user input, bind event listeners, validate inputs
+// ui.js — event binding and input validation
 
-import { getState, setTeamName, setTargetScore, flipBoard, resetState } from "./state.js";
-import { addEntry, undoLastEntry } from "./scoring.js";
+import {
+  getState,
+  setTeamName,
+  setTargetScore,
+  addEntry,
+  undoEntry,
+  resetGame,
+  toggleFlip,
+  acknowledgeWin
+} from "./state.js";
 import { render } from "./renderer.js";
-import { saveState } from "./storage.js";
 
-// Currently-active team for mark entry
-let activeTeamId = "A";
+let selectedTeam = "A";
 let errorTimeout = null;
 
-function persist() {
-  saveState(getState());
-}
+function bindUI() {
+  // Team selection
+  document.getElementById("btn-team-a")?.addEventListener("click", () => selectTeam("A"));
+  document.getElementById("btn-team-b")?.addEventListener("click", () => selectTeam("B"));
 
-function bindEvents() {
-  // Team toggle buttons
-  const btnTeamA = document.getElementById("btn-team-a");
-  const btnTeamB = document.getElementById("btn-team-b");
-  if (btnTeamA) btnTeamA.addEventListener("click", () => setActiveTeam("A"));
-  if (btnTeamB) btnTeamB.addEventListener("click", () => setActiveTeam("B"));
+  // Free score entry
+  const pointsInput = document.getElementById("input-points");
+  document.getElementById("btn-add")?.addEventListener("click", submitPoints);
+  pointsInput?.addEventListener("keydown", e => {
+    if (e.key === "Enter") submitPoints();
+  });
 
-  // Mark entry buttons (+100 / +50 / +20)
-  const markDefs = [
-    { id: "btn-mark-top",  barType: "top"      },
-    { id: "btn-mark-diag", barType: "diagonal" },
-    { id: "btn-mark-bot",  barType: "bottom"   }
-  ];
-  for (const { id, barType } of markDefs) {
-    const btn = document.getElementById(id);
-    if (btn) btn.addEventListener("click", () => handleMarkAdd(barType));
-  }
+  // Quick-add chips for common Jass values
+  document.querySelectorAll(".btn-chip").forEach(chip => {
+    chip.addEventListener("click", () => {
+      recordScore(parseInt(chip.dataset.add, 10));
+    });
+  });
 
-  // Undo button
-  const undoBtn = document.getElementById("btn-undo");
-  if (undoBtn) {
-    undoBtn.addEventListener("click", () => {
-      undoLastEntry();
+  // Undo / reset / flip
+  document.getElementById("btn-undo")?.addEventListener("click", () => {
+    undoEntry();
+    render();
+  });
+  document.getElementById("btn-reset")?.addEventListener("click", () => {
+    if (confirm("Spiel zurücksetzen? Teamnamen und Ziel bleiben erhalten.")) {
+      resetGame();
       render();
-      persist();
-    });
-  }
+    }
+  });
+  document.getElementById("btn-flip")?.addEventListener("click", () => {
+    toggleFlip();
+    render();
+  });
 
-  // Reset button
-  const resetBtn = document.getElementById("btn-reset");
-  if (resetBtn) {
-    resetBtn.addEventListener("click", () => {
-      if (confirm("Reset the game? Team names and target score will be kept.")) {
-        resetState();
-        render();
-        persist();
-        document.getElementById("score-input-area")?.classList.remove("disabled");
-        document.getElementById("win-overlay")?.classList.remove("active");
-      }
-    });
-  }
+  // Team names
+  bindNameInput("edit-name-a", "A");
+  bindNameInput("edit-name-b", "B");
 
-  // Flip button
-  const flipBtn = document.getElementById("btn-flip");
-  if (flipBtn) {
-    flipBtn.addEventListener("click", () => {
-      flipBoard();
-      render();
-      persist();
-    });
-  }
-
-  // Team name edits (save on blur/change)
-  const nameA = document.getElementById("edit-name-a");
-  if (nameA) {
-    nameA.addEventListener("change", () => {
-      const ok = setTeamName("A", nameA.value);
-      if (!ok) nameA.value = getState().teams.find(t => t.id === "A").name;
-      render();
-      persist();
-    });
-  }
-
-  const nameB = document.getElementById("edit-name-b");
-  if (nameB) {
-    nameB.addEventListener("change", () => {
-      const ok = setTeamName("B", nameB.value);
-      if (!ok) nameB.value = getState().teams.find(t => t.id === "B").name;
-      render();
-      persist();
-    });
-  }
-
-  // Target score edit
+  // Target score
   const targetInput = document.getElementById("input-target");
-  if (targetInput) {
-    targetInput.addEventListener("change", () => {
-      const ok = setTargetScore(targetInput.value);
-      if (!ok) {
-        targetInput.value = getState().targetScore;
-        showError("Ziel muss zwischen 100 und 10000 liegen.");
-      } else {
-        render();
-        persist();
-      }
-    });
-  }
+  targetInput?.addEventListener("change", () => {
+    if (!setTargetScore(targetInput.value)) {
+      targetInput.value = getState().targetScore;
+      showError("Ziel muss zwischen 100 und 10000 liegen.");
+      return;
+    }
+    render();
+  });
 
-  // Close win overlay on click
-  const winOverlay = document.getElementById("win-overlay");
-  if (winOverlay) {
-    winOverlay.addEventListener("click", () => {
-      winOverlay.classList.remove("active");
-    });
-  }
+  // Dismiss win overlay
+  document.getElementById("win-overlay")?.addEventListener("click", () => {
+    acknowledgeWin();
+    render();
+  });
+
+  syncInputValues();
+  selectTeam(selectedTeam);
 }
 
-function setActiveTeam(teamId) {
-  activeTeamId = teamId;
-  // Update visual state of toggle buttons
+function bindNameInput(id, teamId) {
+  const input = document.getElementById(id);
+  input?.addEventListener("change", () => {
+    if (!setTeamName(teamId, input.value)) {
+      input.value = getState().teams.find(t => t.id === teamId).name;
+      showError("Name muss 1–30 Zeichen lang sein.");
+      return;
+    }
+    render();
+  });
+}
+
+function selectTeam(teamId) {
+  selectedTeam = teamId;
   document.getElementById("btn-team-a")?.classList.toggle("is-active", teamId === "A");
   document.getElementById("btn-team-b")?.classList.toggle("is-active", teamId === "B");
 }
 
-function handleMarkAdd(barType) {
-  const state = getState();
-  if (state.gameFinished) return;
-
-  const ok = addEntry(activeTeamId, barType);
-  if (ok) {
-    render();
-    persist();
+function submitPoints() {
+  const input = document.getElementById("input-points");
+  if (!input) return;
+  const value = Number(input.value);
+  if (recordScore(value)) {
+    input.value = "";
+    input.focus();
   }
 }
 
-function showError(msg) {
-  const errEl = document.getElementById("error-msg");
-  if (!errEl) return;
-  errEl.textContent = msg;
-  errEl.classList.add("visible");
-  clearTimeout(errorTimeout);
-  errorTimeout = setTimeout(() => errEl.classList.remove("visible"), 3000);
+function recordScore(points) {
+  const error = addEntry(selectedTeam, points);
+  if (error) {
+    showError(error);
+    return false;
+  }
+  render();
+  return true;
 }
 
-function initInputValues() {
+function showError(msg) {
+  const el = document.getElementById("error-msg");
+  if (!el) return;
+  el.textContent = msg;
+  el.classList.add("visible");
+  clearTimeout(errorTimeout);
+  errorTimeout = setTimeout(() => el.classList.remove("visible"), 3000);
+}
+
+function syncInputValues() {
   const state = getState();
   const nameA = document.getElementById("edit-name-a");
   const nameB = document.getElementById("edit-name-b");
-  const targetInput = document.getElementById("input-target");
-
+  const target = document.getElementById("input-target");
   if (nameA) nameA.value = state.teams[0].name;
   if (nameB) nameB.value = state.teams[1].name;
-  if (targetInput) targetInput.value = state.targetScore;
-
-  // Sync active team button visual
-  setActiveTeam(activeTeamId);
+  if (target) target.value = state.targetScore;
 }
 
-export { bindEvents, initInputValues };
+export { bindUI };


### PR DESCRIPTION
Complete rewrite of the Jass scoreboard (requirements: #6) with a new approach, replacing the previous two-stacked-panels implementation.

## The two Z's are readable from both sides

The board is now one coherent SVG slate scene, meant to sit between players facing each other — like a real Jasstafel lying flat on the table:

1. **Each Z is drawn point-symmetric about its own centre** — top bar, diagonal and bottom bar map exactly onto themselves under a 180° rotation, so a Z viewed upside down is still a proper "Z" (never an "S").
2. **The far half of the slate is rotated 180°**, so the far team's name, total and chalk marks face the player across the table.

From either side of the table you always see two correct Z's, and each team reads its own name and total the right way up. The ⇅ button swaps which team sits at the near edge without touching the data model (PRD §10).

## What else changed

- **Free score entry per PRD §6** — any 1–500 points per round (the old version only had fixed +100/+50/+20 buttons, so a normal 157-point round couldn't be recorded), plus quick chips +20/+50/+100/+157
- **Chalk marks derived from the running total** in canonical Schieber notation: 100s on the top bar as tally bundles (`||||\`), 50s on the diagonal, 20s on the bottom bar, remainder written as a chalk number; five twenties auto-exchange into a hundred
- **Deterministic chalk jitter** (seeded PRNG) — hand-drawn look that doesn't wiggle on re-renders
- **Legacy migration** — old localStorage entries (`{barType, value}`) are converted to the PRD entry model `{teamId, points, timestamp}` on load
- **Hardening** — team names are escaped before SVG injection
- PRD-mandated module structure kept: `state.js` / `storage.js` / `scoring.js` / `renderer.js` / `ui.js` / `app.js`, no frameworks

## Verification

Exercised end-to-end in Chromium (Playwright): score entry and validation (501 rejected), chalk decomposition (414 → 4 hundreds + "+ 14"), undo, board flip, persistence across reload, win by exceeding target (entry disabled, undo re-enables), reset preserving names/target/orientation, legacy-entry migration, and HTML-injection-safe team names. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_