### PR TITLE
Jass scoreboard: true chalk semantics — per-round marks, right-aligned 20s, no conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A browser-based digital Jass scoreboard that replicates a traditional Swiss chal
 
 **Features:**
 - One SVG slate scene with two chalk Z's — both readable from both sides of the table (point-symmetric Z geometry, far half rotated 180°)
-- Classic Schieber chalk notation: 100s on the top bar (tally bundles `||||\`), 50s on the diagonal, 20s on the bottom bar, remainder as chalk number
+- Classic Schieber chalk notation: 100s on the top bar (tally bundles `||||\`), 50s on the diagonal, 20s right-aligned on the bottom bar, rest as chalk number — marks stack up per round and are never converted (chalk stays chalk)
 - Free score entry (1–500) plus quick chips (+20/+50/+100/+157)
 - Two teams, editable names and target score (default 2500)
 - Win detection with animated overlay (gold glow, chalk particles)

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -22,23 +22,25 @@ the board (swaps which team sits at the near edge) without touching the data.
 
 ## Chalk notation
 
-Scores are entered as normal round values (1–500). The board decomposes each
-team's running total into the classic Schieber chalk notation:
+Scores are entered as normal round values (1–500). Each round is written to
+the board once, in classic Schieber chalk notation:
 
 | Line | Value per mark |
 |---|---|
 | Top bar | 100 points (bundled tally-style: `||||\` per 500) |
 | Diagonal | 50 points |
-| Bottom bar | 20 points |
-| Chalk number | remainder below 20 (e.g. `+ 17`) |
+| Bottom bar | 20 points, aligned right, growing towards the left |
+| Chalk number | sum of all sub-20 rests (e.g. `+ 17`) |
 
-The board is always kept canonical — five twenties are automatically
-"exchanged" for a hundred, like a tidy chalk writer would do.
+True chalk semantics: once a mark is written it stays on the board. Marks
+simply stack up round after round — there is **no automatic conversion**
+(five twenties are never exchanged for a hundred, two fifties never become
+a hundred). Only ↩ Rückgängig wipes the last round's marks again.
 
 ## Features
 
 - 🧮 **Free score entry** — any 1–500 points per round, plus quick chips (+20/+50/+100/+157)
-- ✏️ **Chalk marks derived from totals** — authentic 100/50/20 notation on the Z lines
+- ✏️ **Chalk marks per round** — authentic 100/50/20 notation on the Z lines, marks accumulate and are never converted
 - 🔄 **Deterministic chalk jitter** — hand-drawn look that stays stable across re-renders
 - 🏆 **Win detection** — a team wins by *exceeding* the target (default 2500)
 - ↩ **Undo** — remove the last recorded round (also after a win)

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -10,7 +10,7 @@
 // "S" — no matter which side of the table you look from.
 
 import { getState } from "./state.js";
-import { decompose } from "./scoring.js";
+import { computeMarks } from "./scoring.js";
 
 // ── Board geometry (one half, local coordinates) ─────────────────
 const W = 640;        // board width
@@ -85,7 +85,8 @@ function hundredMarks(rand, count) {
 }
 
 /**
- * Fifties as strokes crossing the diagonal, laid out along it.
+ * Fifties as strokes crossing the diagonal, accumulating along it
+ * from the top-right end.
  */
 function fiftyMarks(rand, count) {
   if (!count) return "";
@@ -97,9 +98,12 @@ function fiftyMarks(rand, count) {
   const px = -uy; // perpendicular unit vector
   const py = ux;
 
+  const startFrac = 0.14;
+  const spanFrac = 0.72;
+  const stepFrac = Math.min(0.1, spanFrac / count);
   let out = "";
   for (let i = 0; i < count; i++) {
-    const t = len * Math.min(0.85, 0.3 + i * 0.11);
+    const t = len * (startFrac + (i + 0.5) * stepFrac);
     const cx = XR + ux * t;
     const cy = TOP_Y + uy * t;
     out += chalkLine(rand, cx - px * 18, cy - py * 18, cx + px * 18, cy + py * 18, 3.2, "mark");
@@ -108,16 +112,18 @@ function fiftyMarks(rand, count) {
 }
 
 /**
- * Twenties as upright strokes on the bottom bar (at most two appear —
- * five twenties are auto-exchanged for a hundred by decompose()).
+ * Twenties as upright strokes on the bottom bar. They align right and
+ * grow towards the left, simply stacking up round after round — no
+ * exchanging into fifties or hundreds, chalk stays where it was
+ * written.
  */
 function twentyMarks(rand, count) {
   if (!count) return "";
   const usable = XR - XL - 24;
-  const step = Math.min(22, usable / Math.max(1, count));
+  const step = Math.min(22, Math.max(7, usable / count));
   let out = "";
   for (let i = 0; i < count; i++) {
-    const x = XL + 12 + i * step;
+    const x = XR - 12 - i * step;
     out += chalkLine(rand, x, BOT_Y - 17, x + (rand() * 4 - 2), BOT_Y + 17, 3.2, "mark");
   }
   return out;
@@ -127,9 +133,9 @@ function twentyMarks(rand, count) {
  * One team's half of the slate, drawn in local coordinates for a
  * viewer sitting at that half's outer edge.
  */
-function buildHalf(team, total, isWinner, seed) {
+function buildHalf(team, total, marks, isWinner, seed) {
   const rand = mulberry32(seed);
-  const { hundreds, fifties, twenties, remainder } = decompose(total);
+  const { hundreds, fifties, twenties, remainder } = marks;
 
   let s = "";
   if (isWinner) {
@@ -159,7 +165,7 @@ function buildHalf(team, total, isWinner, seed) {
   s += twentyMarks(rand, twenties);
   s += `</g>`;
 
-  // Remainder below 20 written as a chalk number
+  // Sum of all sub-20 rests, written as a chalk number
   if (remainder > 0) {
     s += `<text class="rest-num" x="${XR}" y="${BOT_Y + 56}" text-anchor="end">+ ${remainder}</text>`;
   }
@@ -174,6 +180,7 @@ function render() {
   // the data model itself never changes
   const farTeam = state.flipped ? state.teams[1] : state.teams[0];
   const nearTeam = state.flipped ? state.teams[0] : state.teams[1];
+  const marks = computeMarks(state.entries);
 
   const svg = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jasstafel: ${esc(farTeam.name)} ${state.totals[farTeam.id]} Punkte, ${esc(nearTeam.name)} ${state.totals[nearTeam.id]} Punkte">
     <defs>
@@ -183,9 +190,9 @@ function render() {
       </filter>
     </defs>
     <rect class="board-frame" x="10" y="10" width="${W - 20}" height="${H - 20}" rx="16"/>
-    <g transform="rotate(180 ${W / 2} ${HH / 2})">${buildHalf(farTeam, state.totals[farTeam.id], state.winner === farTeam.id, 11)}</g>
+    <g transform="rotate(180 ${W / 2} ${HH / 2})">${buildHalf(farTeam, state.totals[farTeam.id], marks[farTeam.id], state.winner === farTeam.id, 11)}</g>
     <line class="board-divider" x1="26" y1="${HH}" x2="${W - 26}" y2="${HH}"/>
-    <g transform="translate(0 ${HH})">${buildHalf(nearTeam, state.totals[nearTeam.id], state.winner === nearTeam.id, 47)}</g>
+    <g transform="translate(0 ${HH})">${buildHalf(nearTeam, state.totals[nearTeam.id], marks[nearTeam.id], state.winner === nearTeam.id, 47)}</g>
   </svg>`;
 
   const board = document.getElementById("board");

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -34,15 +34,13 @@ function findWinner(totals, targetScore) {
 }
 
 /**
- * Decompose a running total into classic Schieber chalk notation:
+ * Decompose a single round's points into chalk strokes:
  * hundreds on the top bar, fifties on the diagonal, twenties on the
- * bottom bar, remainder written as a number. The board is always kept
- * in canonical form — five twenties are automatically "exchanged" for
- * a hundred, exactly like a tidy chalk writer would do.
+ * bottom bar, rest below 20 as a number.
  */
-function decompose(total) {
-  const hundreds = Math.floor(total / 100);
-  let rest = total % 100;
+function decomposeEntry(points) {
+  const hundreds = Math.floor(points / 100);
+  let rest = points % 100;
   const fifties = Math.floor(rest / 50);
   rest %= 50;
   const twenties = Math.floor(rest / 20);
@@ -50,4 +48,28 @@ function decompose(total) {
   return { hundreds, fifties, twenties, remainder: rest };
 }
 
-export { validatePoints, computeTotals, findWinner, decompose };
+/**
+ * Accumulate chalk marks over the whole entry sequence — real chalk
+ * semantics: each round is written once and its strokes stay on the
+ * board forever. Marks are NEVER converted between lines (no
+ * exchanging five twenties for a hundred); the rest numbers simply
+ * add up.
+ */
+function computeMarks(entries) {
+  const marks = {
+    A: { hundreds: 0, fifties: 0, twenties: 0, remainder: 0 },
+    B: { hundreds: 0, fifties: 0, twenties: 0, remainder: 0 }
+  };
+  for (const e of entries) {
+    const team = marks[e.teamId];
+    if (!team || !Number.isFinite(e.points)) continue;
+    const d = decomposeEntry(e.points);
+    team.hundreds += d.hundreds;
+    team.fifties += d.fifties;
+    team.twenties += d.twenties;
+    team.remainder += d.remainder;
+  }
+  return marks;
+}
+
+export { validatePoints, computeTotals, findWinner, decomposeEntry, computeMarks };


### PR DESCRIPTION
Follow-up to #10, implementing the chalk-behaviour feedback:

- **Per-round marks instead of total-derived marks** — each round's points are written to the board once (100s on the top bar, 50s on the diagonal, 20s on the bottom bar, sub-20 rest as a number) and the strokes stay there. There is **no automatic conversion**: five twenties are never exchanged for a hundred, two fifties never become a hundred — chalk stays where it was written.
- **20s align right** on the bottom bar and grow towards the left, simply stacking up round after round with adaptive spacing.
- Fifties accumulate along the diagonal; sub-20 rests add up into the `+ N` chalk figure.
- Marks can only disappear via ↩ Rückgängig, which wipes exactly the last round's strokes.

## Verification

Exercised in Chromium (Playwright): five 20-point rounds stay five separate right-aligned strokes (total 100, no 100-mark appears), stroke x-positions descend from the right end of the bar, 90 → one fifty + two twenties, rests accumulate (`+ 17`), and undo removes only the last round's marks. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_