### PR TITLE
Jass scoreboard: bundle 20s and 50s tally-style like the 100s, tighter 50 spacing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Repository
+
+Small static browser apps (HTML/CSS/vanilla JS, no frameworks, no build
+step). Each app lives in its own folder or as a single HTML file and must
+run from a static web server (ES modules require http, e.g.
+`python3 -m http.server`).
+
+## Mandatory verification workflow
+
+For every UI change, before reporting back or opening/updating a PR:
+
+1. **Test it yourself in a real browser.** Serve the app locally and drive
+   the changed flows end-to-end with Playwright (Chromium is pre-installed
+   at `/opt/pw-browsers/chromium`). Exercise the actual feature that
+   changed — not just a page load — and check for console errors.
+2. **Always take screenshots and provide them to the user.** Capture the
+   relevant states (normal view plus any changed/special states) and send
+   them with the summary. A change without a screenshot is not done.
+
+## App notes
+
+### jass-scoreboard
+
+- Requirements PRD: issue #6. Module structure (`state.js`, `storage.js`,
+  `scoring.js`, `renderer.js`, `ui.js`, `app.js`) is mandated by the PRD.
+- The board is one SVG scene; each Z is point-symmetric so both Z's read
+  correctly from both sides of the table (far half rotated 180°).
+- Chalk semantics: marks are written per round and never converted
+  between lines (no exchanging five 20s for a 100); 20s align right on
+  the bottom bar; all lines bundle tallies in fives (`||||\`); only undo
+  removes the last round's marks.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A browser-based digital Jass scoreboard that replicates a traditional Swiss chal
 
 **Features:**
 - One SVG slate scene with two chalk Z's — both readable from both sides of the table (point-symmetric Z geometry, far half rotated 180°)
-- Classic Schieber chalk notation: 100s on the top bar (tally bundles `||||\`), 50s on the diagonal, 20s right-aligned on the bottom bar, rest as chalk number — marks stack up per round and are never converted (chalk stays chalk)
+- Classic Schieber chalk notation: 100s on the top bar, 50s on the diagonal, 20s right-aligned on the bottom bar — all bundled tally-style (`||||\`), rest as chalk number; marks stack up per round and are never converted (chalk stays chalk)
 - Free score entry (1–500) plus quick chips (+20/+50/+100/+157)
 - Two teams, editable names and target score (default 2500)
 - Win detection with animated overlay (gold glow, chalk particles)

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -27,10 +27,13 @@ the board once, in classic Schieber chalk notation:
 
 | Line | Value per mark |
 |---|---|
-| Top bar | 100 points (bundled tally-style: `||||\` per 500) |
-| Diagonal | 50 points |
+| Top bar | 100 points, left-aligned |
+| Diagonal | 50 points, compact spacing from the top-right end |
 | Bottom bar | 20 points, aligned right, growing towards the left |
 | Chalk number | sum of all sub-20 rests (e.g. `+ 17`) |
+
+All three lines bundle their marks tally-style: every fifth stroke is a
+slash across the previous four (`||||\`).
 
 True chalk semantics: once a mark is written it stays on the board. Marks
 simply stack up round after round — there is **no automatic conversion**

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -53,42 +53,51 @@ function chalkLine(rand, x1, y1, x2, y2, width, cls) {
   return `<line class="${cls}" x1="${(x1 + j()).toFixed(1)}" y1="${(y1 + j()).toFixed(1)}" x2="${(x2 + j()).toFixed(1)}" y2="${(y2 + j()).toFixed(1)}" stroke-width="${width}" stroke-linecap="round"/>`;
 }
 
-/**
- * Hundreds on the top bar, bundled tally-style: four upright strokes
- * plus a diagonal slash across them for each complete group of five.
- */
-function hundredMarks(rand, count) {
-  if (!count) return "";
-  const usable = XR - XL - 24;
+function splitGroups(count) {
   const groups = [];
   for (let left = count; left > 0; left -= 5) groups.push(Math.min(left, 5));
+  return groups;
+}
+
+/**
+ * Tally marks on a horizontal bar, bundled in fives: four upright
+ * strokes plus a slash across them for each complete group (||||\).
+ * dir 1 = left-aligned growing right (hundreds), dir -1 =
+ * right-aligned growing left (twenties). Marks stack up in place —
+ * no conversion between lines, chalk stays where it was written.
+ */
+function barTallies(rand, count, y, dir) {
+  if (!count) return "";
+  const usable = XR - XL - 24;
+  const groups = splitGroups(count);
   const uprightTotal = groups.reduce((sum, c) => sum + Math.min(c, 4), 0);
   const GAP = 26;
   const denom = Math.max(1, uprightTotal - groups.length);
   const step = Math.max(7, Math.min(19, (usable - (groups.length - 1) * GAP) / denom));
 
-  let x = XL + 12;
+  let x = dir === 1 ? XL + 12 : XR - 12;
   let out = "";
   for (const cnt of groups) {
     const uprights = Math.min(cnt, 4);
     for (let k = 0; k < uprights; k++) {
-      const ux = x + k * step;
-      out += chalkLine(rand, ux, TOP_Y - 17, ux + (rand() * 4 - 2), TOP_Y + 17, 3.2, "mark");
+      const ux = x + dir * k * step;
+      out += chalkLine(rand, ux, y - 17, ux + (rand() * 4 - 2), y + 17, 3.2, "mark");
     }
     const groupWidth = (uprights - 1) * step;
     if (cnt === 5) {
-      out += chalkLine(rand, x - step * 0.45, TOP_Y + 16, x + groupWidth + step * 0.45, TOP_Y - 16, 3.2, "mark");
+      out += chalkLine(rand, x - dir * step * 0.45, y + 16, x + dir * (groupWidth + step * 0.45), y - 16, 3.2, "mark");
     }
-    x += groupWidth + GAP;
+    x += dir * (groupWidth + GAP);
   }
   return out;
 }
 
 /**
- * Fifties as strokes crossing the diagonal, accumulating along it
- * from the top-right end.
+ * Fifties as strokes crossing the diagonal, accumulating compactly
+ * from the top-right end and bundled in fives like the other lines:
+ * four cross-strokes plus a slash through them per complete group.
  */
-function fiftyMarks(rand, count) {
+function diagTallies(rand, count) {
   if (!count) return "";
   const dx = XL - XR;
   const dy = BOT_Y - TOP_Y;
@@ -97,34 +106,30 @@ function fiftyMarks(rand, count) {
   const uy = dy / len;
   const px = -uy; // perpendicular unit vector
   const py = ux;
+  const point = t => [XR + ux * t, TOP_Y + uy * t];
 
-  const startFrac = 0.14;
-  const spanFrac = 0.72;
-  const stepFrac = Math.min(0.1, spanFrac / count);
-  let out = "";
-  for (let i = 0; i < count; i++) {
-    const t = len * (startFrac + (i + 0.5) * stepFrac);
-    const cx = XR + ux * t;
-    const cy = TOP_Y + uy * t;
-    out += chalkLine(rand, cx - px * 18, cy - py * 18, cx + px * 18, cy + py * 18, 3.2, "mark");
-  }
-  return out;
-}
+  const groups = splitGroups(count);
+  const uprightTotal = groups.reduce((sum, c) => sum + Math.min(c, 4), 0);
+  const GAP = 36;
+  const usable = len * 0.8;
+  const denom = Math.max(1, uprightTotal - groups.length);
+  const step = Math.max(12, Math.min(26, (usable - (groups.length - 1) * GAP) / denom));
 
-/**
- * Twenties as upright strokes on the bottom bar. They align right and
- * grow towards the left, simply stacking up round after round — no
- * exchanging into fifties or hundreds, chalk stays where it was
- * written.
- */
-function twentyMarks(rand, count) {
-  if (!count) return "";
-  const usable = XR - XL - 24;
-  const step = Math.min(22, Math.max(7, usable / count));
+  let t = len * 0.1;
   let out = "";
-  for (let i = 0; i < count; i++) {
-    const x = XR - 12 - i * step;
-    out += chalkLine(rand, x, BOT_Y - 17, x + (rand() * 4 - 2), BOT_Y + 17, 3.2, "mark");
+  for (const cnt of groups) {
+    const uprights = Math.min(cnt, 4);
+    for (let k = 0; k < uprights; k++) {
+      const [cx, cy] = point(t + k * step);
+      out += chalkLine(rand, cx - px * 18, cy - py * 18, cx + px * 18, cy + py * 18, 3.2, "mark");
+    }
+    const groupSpan = (uprights - 1) * step;
+    if (cnt === 5) {
+      const [sx, sy] = point(t - step * 0.45);
+      const [ex, ey] = point(t + groupSpan + step * 0.45);
+      out += chalkLine(rand, sx + px * 12, sy + py * 12, ex - px * 12, ey - py * 12, 3.2, "mark");
+    }
+    t += groupSpan + GAP;
   }
   return out;
 }
@@ -160,9 +165,9 @@ function buildHalf(team, total, marks, isWinner, seed) {
 
   // Chalk marks
   s += `<g class="marks" filter="url(#chalk-rough)">`;
-  s += hundredMarks(rand, hundreds);
-  s += fiftyMarks(rand, fifties);
-  s += twentyMarks(rand, twenties);
+  s += barTallies(rand, hundreds, TOP_Y, 1);
+  s += diagTallies(rand, fifties);
+  s += barTallies(rand, twenties, BOT_Y, -1);
   s += `</g>`;
 
   // Sum of all sub-20 rests, written as a chalk number


### PR DESCRIPTION
Follow-up to #11:

- **20s and 50s now bundle in fives** exactly like the 100s: four strokes plus a slash across them per complete group (`||||\`). The bar tally renderer is generalized and used left-aligned for the 100s and right-aligned for the 20s; the diagonal gets its own variant with the slash running along the diagonal through the four cross-strokes.
- **50s are spaced compactly** from the top-right end of the diagonal (fixed small gaps that only compress when space runs out), instead of spreading over the whole line.
- Chalk semantics from #11 are unchanged: marks stack up per round, nothing is ever converted between lines.

## Verification

Chromium (Playwright): 6×100 renders as one bundle + one stroke (6 lines) on the top bar; 7×50 as one slashed bundle + two strokes compactly on the diagonal; 12×20 as two right-aligned slashed bundles + two strokes on the bottom bar. Totals correct (600 / 590), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_