### PR TITLE
Jass scoreboard: Playwright e2e test suite, spec-sync rules, inline favicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,15 +25,22 @@ For every UI change, before reporting back or opening/updating a PR:
    it must pass before reporting back. For jass-scoreboard:
    `cd jass-scoreboard/tests && npm install && node e2e.test.mjs`.
 4. **Keep specs in sync.** Whenever behavior changes, update the spec in
-   the same change so it always reflects reality: the PRD issue (issue #6
-   for jass-scoreboard), the app's README, and this file's app notes.
+   the same change so it always reflects reality. The PRD is a file in
+   the app folder (`jass-scoreboard/PRD.md`) and is the single source of
+   truth; the README is user-facing only (what it is, how to use/run/
+   test) and must not duplicate spec detail. Also update this file's app
+   notes.
 
 ## App notes
 
 ### jass-scoreboard
 
-- Requirements PRD: issue #6. Module structure (`state.js`, `storage.js`,
-  `scoring.js`, `renderer.js`, `ui.js`, `app.js`) is mandated by the PRD.
+- Requirements PRD: `jass-scoreboard/PRD.md`. Module structure
+  (`state.js`, `storage.js`, `scoring.js`, `renderer.js`, `ui.js`,
+  `app.js`) is mandated by the PRD.
+- Cache busting: every local asset URL (CSS link, script tag, every
+  inter-module import) carries the same `?v=N`. Bump N in ALL files on
+  every release — the e2e suite fails on divergence.
 - The board is one SVG scene; each Z is point-symmetric so both Z's read
   correctly from both sides of the table (far half rotated 180°).
 - Chalk semantics: marks are written per round and never converted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,5 @@ For every UI change, before reporting back or opening/updating a PR:
 - Chalk semantics: marks are written per round and never converted
   between lines (no exchanging five 20s for a 100); 20s align right on
   the bottom bar; all lines bundle tallies in fives (`||||\`); only undo
-  removes the last round's marks.
+  removes the last round's marks. The rest number is always below 20 —
+  at 20 it carries into a 20-mark.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,13 @@ For every UI change, before reporting back or opening/updating a PR:
 2. **Always take screenshots and provide them to the user.** Capture the
    relevant states (normal view plus any changed/special states) and send
    them with the summary. A change without a screenshot is not done.
+3. **Automated tests live in `<app>/tests/`.** Write or extend the
+   Playwright e2e suite there for every behavior change, and run it —
+   it must pass before reporting back. For jass-scoreboard:
+   `cd jass-scoreboard/tests && npm install && node e2e.test.mjs`.
+4. **Keep specs in sync.** Whenever behavior changes, update the spec in
+   the same change so it always reflects reality: the PRD issue (issue #6
+   for jass-scoreboard), the app's README, and this file's app notes.
 
 ## App notes
 

--- a/jass-scoreboard/PRD.md
+++ b/jass-scoreboard/PRD.md
@@ -1,0 +1,156 @@
+# PRD — Digital Jass Scoreboard (Schiefertafel Z/Z)
+
+Version: 2.2 (as built — this file is the single source of truth and is
+updated in the same change whenever behavior changes)
+
+## 1. Product
+
+A browser-based scoreboard replicating a traditional Swiss Jass slate
+(Jasstafel) with Z/Z representation. The board is one SVG scene — a slate
+lying flat on the table between two teams — with one chalk **Z** per team.
+It must be extremely fast to use during gameplay, visually similar to
+physical Jasstafeln, and deployable as a static web app.
+
+## 2. Constraints
+
+- HTML5, CSS3, Vanilla JavaScript (ES6+ modules) only.
+- Forbidden: React, Angular, Vue, jQuery, TypeScript, external JS
+  frameworks; external CSS libraries should be avoided.
+- No binary assets: slate, wood frame, chalk look and favicon are pure
+  CSS/SVG (favicon is an inline SVG data URI).
+- Tests are exempt: the Playwright suite under `tests/` may use npm
+  packages — tooling, not shipped app code.
+
+## 3. Structure & Responsibilities
+
+```
+jass-scoreboard/
+├── index.html          root structure, DOM containers, loads CSS/JS
+├── css/styles.css      layout, slate/chalk styling, animations
+├── js/
+│   ├── app.js          bootstrap: restore → init → bind → render
+│   ├── state.js        global state, mutations, validation
+│   ├── storage.js      localStorage persistence + legacy migration
+│   ├── scoring.js      validation, totals, win check, mark accumulation
+│   ├── renderer.js     single-SVG slate scene: Z's, marks, totals, win
+│   └── ui.js           event binding, input validation
+├── tests/e2e.test.mjs  Playwright end-to-end tests
+├── PRD.md              this file
+└── README.md           user-facing: what it is, how to use/run/test
+```
+
+## 4. Data Model
+
+```js
+state = {
+  teams: [{ id: "A", name: "Team A" }, { id: "B", name: "Team B" }],
+  entries: [],                    // [{ teamId, points, timestamp }]
+  totals: { A: 0, B: 0 },         // derived, never edited
+  targetScore: 2500,
+  flipped: false,
+  winner: null,
+  gameFinished: false,
+  winAcknowledged: false          // transient, never persisted
+}
+```
+
+Chalk marks are derived from the entry sequence, never stored.
+
+## 5. Game Rules
+
+- Exactly two teams; names editable, 1–30 characters.
+- Target score: default 2500, editable, range 100–10000.
+- Win: `team_total > targetScore` (must strictly exceed).
+- On win: score entry disabled; undo and reset remain available.
+
+## 6. Score Entry
+
+1. Select team (toggle buttons showing team names)
+2. Enter points or tap a quick chip: +20 / +50 / +100 / +157
+3. **Eintragen** (Enter also submits)
+
+Validation: integer, `0 < points ≤ 500`. Errors shown in German in an
+`aria-live` region.
+
+## 7. Chalk Mark Rendering
+
+Each round is decomposed once, at entry time:
+
+| Line | Value per mark | Layout |
+|---|---|---|
+| Top bar | 100 | left-aligned |
+| Diagonal | 50 | compact from the top-right end |
+| Bottom bar | 20 | **aligned right**, growing left |
+| Chalk number | sub-20 rest | always below 20 |
+
+Hard rules (chalk semantics):
+
+- Marks accumulate round after round and are **never converted** between
+  lines (no exchanging five 20s for a 100, or two 50s for a 100).
+- A written mark disappears only through **Undo**, which wipes exactly
+  the last round's marks.
+- All three lines bundle tallies in fives: every fifth stroke is a slash
+  across the previous four (`||||\`) — display grouping, never conversion.
+- The rest number never reaches 20: rests add up, and at 20 a 20-mark is
+  written and the number rewritten with the leftover (numerals are the
+  one thing a chalk writer wipes and rewrites).
+- Round entries never display numeric values; only the running total and
+  the rest number are numerals.
+- Chalk strokes use deterministic jitter (seeded PRNG): the hand-drawn
+  look is stable across re-renders — marks never wiggle or move.
+
+## 8. Board Layout — readable from both sides
+
+- Two halves separated by a red centre line; one Z per half.
+- Each Z is **point-symmetric about its own centre**: top bar, diagonal
+  and bottom bar map onto themselves under a 180° rotation, so a Z viewed
+  upside down is still a "Z", never an "S".
+- The far half is rotated 180° so that team's name, total and marks face
+  the player across the table.
+- The ⇅ button toggles `flipped`, swapping which team sits at the near
+  edge; the data model never changes.
+
+## 9. Undo & Reset
+
+- Undo: `entries.pop()` → recompute totals/marks/winner → re-render.
+  Undo also revives a finished game.
+- Reset (with confirmation): clears entries, totals, winner,
+  gameFinished; keeps team names, target score, flip state.
+
+## 10. Persistence & Caching
+
+- `localStorage`, key `jassScoreboardState`; saved fields: teams,
+  entries, targetScore, flipped, winner, gameFinished.
+- Totals and marks are recomputed on load, never trusted from storage.
+- Legacy v1 entries (`{barType, value}`) are migrated to `{points}`.
+- Cache busting: every local asset URL (CSS link, script tag, and every
+  inter-module import) carries the same `?v=N` query. Bump `N` in all
+  files on every release; the e2e suite fails if versions diverge or an
+  asset URL is unversioned.
+
+## 11. UI & Accessibility
+
+- DOM: header (title, target, ⇅) · name editors · `#board` ·
+  screen-reader live region · input area (team toggle, points +
+  Eintragen, chips, Rückgängig/Neu) · win overlay.
+- UI language: German, Swiss spelling (no ß).
+- Win animation: overlay (trophy, "Gewonnen!", chalk particles), pulsing
+  gold glow on the winning half; tap to dismiss.
+- Responsive from 320px; keyboard operable; visible focus rings;
+  `prefers-reduced-motion` respected; user input escaped before SVG
+  injection.
+- Performance: initial load < 1s, score update < 50ms.
+
+## 12. Testing
+
+- Playwright e2e tests in `tests/` must pass before any change is
+  reported or a PR is opened/updated.
+- Tests exercise real flows in Chromium (entry, validation, chalk
+  semantics, bundling, rest carry, undo, flip, persistence, win, reset,
+  escaping, cache-version consistency) and fail on console errors.
+- Screenshots of changed states accompany every change report.
+
+## 13. Out of Scope
+
+Multiple Jass variants, multiplayer sync, PWA install, statistics,
+export screenshot, tournament mode.

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -75,8 +75,24 @@ jass-scoreboard/
 │   ├── scoring.js      # Validation, totals, win check, chalk decomposition
 │   ├── renderer.js     # Single-SVG slate scene: Z's, marks, totals, win state
 │   └── ui.js           # Event binding and input validation
+├── tests/
+│   ├── e2e.test.mjs    # Playwright end-to-end tests
+│   └── package.json    # Test-only dependencies (playwright)
 └── README.md
 ```
+
+## Tests
+
+```
+cd tests
+npm install
+node e2e.test.mjs
+```
+
+Spawns its own static server, drives the real flows in Chromium (entry,
+validation, chalk semantics, bundling, undo, flip, persistence, win,
+reset, escaping) and fails on any console error. Screenshots land in
+`tests/screenshots/`.
 
 ## Technologies
 

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -30,7 +30,7 @@ the board once, in classic Schieber chalk notation:
 | Top bar | 100 points, left-aligned |
 | Diagonal | 50 points, compact spacing from the top-right end |
 | Bottom bar | 20 points, aligned right, growing towards the left |
-| Chalk number | sum of all sub-20 rests (e.g. `+ 17`) |
+| Chalk number | sub-20 rest — always below 20; at 20 it carries into a 20-mark |
 
 All three lines bundle their marks tally-style: every fifth stroke is a
 slash across the previous four (`||||\`).
@@ -39,6 +39,11 @@ True chalk semantics: once a mark is written it stays on the board. Marks
 simply stack up round after round — there is **no automatic conversion**
 (five twenties are never exchanged for a hundred, two fifties never become
 a hundred). Only ↩ Rückgängig wipes the last round's marks again.
+
+The one exception is the rest **number**: numerals are the one thing a
+chalk writer wipes and rewrites. Sub-20 rests add up, and whenever the
+accumulated rest reaches 20, a 20-mark is written on the bottom bar and
+the number is rewritten with what's left — so it never shows 20 or more.
 
 ## Features
 

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -1,90 +1,30 @@
 # Jass Tafel — Schiefertafel Z/Z
 
-A browser-based digital Jass scoreboard that replicates a traditional Swiss chalk
-slate board (Jasstafel). The whole board is rendered as **one SVG slate scene**
-with two chalk **Z** shapes — one per team — exactly like the physical board
-lying flat on the table between the two teams.
+A digital Swiss Jass slate for the browser: one chalk board with two
+**Z**'s, lying (virtually) flat on the table between the two teams. Both
+Z's read correctly from both sides of the table, and each team sees its
+own name and total the right way up.
 
-## The two Z's are readable from both sides
+Full requirements and behavior rules live in [PRD.md](PRD.md) — this
+README only covers what it is and how to use it.
 
-Like a real Jasstafel, the board is meant to sit between players facing each
-other. Two things make it work:
+## How to use
 
-1. **Each Z is drawn point-symmetric about its own centre** — the top bar, the
-   diagonal and the bottom bar map exactly onto themselves under a 180°
-   rotation. A "Z" viewed upside down is still a "Z" (never an "S").
-2. **The far half of the slate is rotated 180°**, so the far team's name,
-   total and marks face the player sitting across the table.
+1. Serve the folder from any static web server (ES modules need http):
+   `python3 -m http.server` → open `http://localhost:8000/index.html`
+2. Edit team names and the target score (default 2500) at the top.
+3. Select a team, type the round points (1–500) and hit **Eintragen** —
+   or tap a quick chip (+20 / +50 / +100 / +157).
+4. **↩ Rückgängig** wipes the last round's marks, **🔄 Neu** starts a new
+   game, **⇅** rotates the board for the players across the table.
+5. A team wins by *exceeding* the target. The game survives page
+   reloads (localStorage).
 
-The result: from *either* side of the table you always see two proper Z's, and
-each team reads its own name and total the right way up. The ⇅ button rotates
-the board (swaps which team sits at the near edge) without touching the data.
-
-## Chalk notation
-
-Scores are entered as normal round values (1–500). Each round is written to
-the board once, in classic Schieber chalk notation:
-
-| Line | Value per mark |
-|---|---|
-| Top bar | 100 points, left-aligned |
-| Diagonal | 50 points, compact spacing from the top-right end |
-| Bottom bar | 20 points, aligned right, growing towards the left |
-| Chalk number | sub-20 rest — always below 20; at 20 it carries into a 20-mark |
-
-All three lines bundle their marks tally-style: every fifth stroke is a
-slash across the previous four (`||||\`).
-
-True chalk semantics: once a mark is written it stays on the board. Marks
-simply stack up round after round — there is **no automatic conversion**
-(five twenties are never exchanged for a hundred, two fifties never become
-a hundred). Only ↩ Rückgängig wipes the last round's marks again.
-
-The one exception is the rest **number**: numerals are the one thing a
-chalk writer wipes and rewrites. Sub-20 rests add up, and whenever the
-accumulated rest reaches 20, a 20-mark is written on the bottom bar and
-the number is rewritten with what's left — so it never shows 20 or more.
-
-## Features
-
-- 🧮 **Free score entry** — any 1–500 points per round, plus quick chips (+20/+50/+100/+157)
-- ✏️ **Chalk marks per round** — authentic 100/50/20 notation on the Z lines, marks accumulate and are never converted
-- 🔄 **Deterministic chalk jitter** — hand-drawn look that stays stable across re-renders
-- 🏆 **Win detection** — a team wins by *exceeding* the target (default 2500)
-- ↩ **Undo** — remove the last recorded round (also after a win)
-- 🆕 **Reset** — clear scores, keep team names / target / orientation
-- ⇅ **Rotate board** — swap which team faces the near edge
-- 💾 **Persistence** — state saved to `localStorage` (`jassScoreboardState`), old-format entries are migrated
-- 📱 **Responsive** — mobile (320px+), tablet, desktop
-- ♿ **Accessible** — keyboard operable, live screen-reader status, reduced-motion support
-
-## Usage
-
-1. Open `index.html` via any static web server (ES modules require http, e.g. `python3 -m http.server`)
-2. Edit team names and the target score at the top
-3. Select a team, type the round points (or tap a quick chip)
-4. **Eintragen** records the round; **↩ Rückgängig** undoes; **🔄 Neu** resets
-5. **⇅** rotates the board for the players on the other side of the table
-
-## Project Structure
-
-```
-jass-scoreboard/
-├── index.html          # Root HTML structure, DOM containers
-├── css/
-│   └── styles.css      # Slate/chalk styling, layout, animations
-├── js/
-│   ├── app.js          # Application bootstrap
-│   ├── state.js        # Global state definition and mutations
-│   ├── storage.js      # localStorage persistence + legacy migration
-│   ├── scoring.js      # Validation, totals, win check, chalk decomposition
-│   ├── renderer.js     # Single-SVG slate scene: Z's, marks, totals, win state
-│   └── ui.js           # Event binding and input validation
-├── tests/
-│   ├── e2e.test.mjs    # Playwright end-to-end tests
-│   └── package.json    # Test-only dependencies (playwright)
-└── README.md
-```
+Rounds are written as chalk marks like on a real Jasstafel: 100s on the
+top bar, 50s on the diagonal, 20s right-aligned on the bottom bar (all
+bundled in fives, `||||\`), plus a rest number that always stays below 20.
+Marks are never converted between lines — chalk stays where it was
+written.
 
 ## Tests
 
@@ -94,18 +34,10 @@ npm install
 node e2e.test.mjs
 ```
 
-Spawns its own static server, drives the real flows in Chromium (entry,
-validation, chalk semantics, bundling, undo, flip, persistence, win,
-reset, escaping) and fails on any console error. Screenshots land in
-`tests/screenshots/`.
+Spawns its own static server and drives the real flows in Chromium.
+Screenshots land in `tests/screenshots/`.
 
-## Technologies
+## Tech
 
-HTML5, CSS3, Vanilla JavaScript (ES6 modules). No frameworks, no external libraries.
-
-## Game Rules
-
-- Two teams record scores round by round
-- A team wins when its total **exceeds** the target score (default **2500**)
-- Valid point entries: integers from 1 to 500
-- After a win, score entry is disabled; undo and reset remain available
+HTML5, CSS3, Vanilla JavaScript (ES6 modules). No frameworks, no build
+step, no binary assets.

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jass Tafel — Schiefertafel Z/Z</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='18' fill='%23232e28'/%3E%3Cpath d='M25 32h50L25 68h50' stroke='%23f2efe4' stroke-width='9' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
-  <link rel="stylesheet" href="css/styles.css" />
+  <!-- Cache busting: bump ?v= here AND in every js import on each release -->
+  <link rel="stylesheet" href="css/styles.css?v=3" />
 </head>
 <body>
   <!-- Win overlay -->
@@ -94,6 +95,6 @@
     </div>
   </div>
 
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="js/app.js?v=3"></script>
 </body>
 </html>

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Jass Tafel — Schiefertafel Z/Z</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='18' fill='%23232e28'/%3E%3Cpath d='M25 32h50L25 68h50' stroke='%23f2efe4' stroke-width='9' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>

--- a/jass-scoreboard/js/app.js
+++ b/jass-scoreboard/js/app.js
@@ -1,9 +1,9 @@
 // app.js — application bootstrap
 
-import { initState } from "./state.js";
-import { loadState } from "./storage.js";
-import { bindUI } from "./ui.js";
-import { render } from "./renderer.js";
+import { initState } from "./state.js?v=3";
+import { loadState } from "./storage.js?v=3";
+import { bindUI } from "./ui.js?v=3";
+import { render } from "./renderer.js?v=3";
 
 function bootstrap() {
   initState(loadState());

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -9,8 +9,8 @@
 // symmetry both Z shapes still read as a proper "Z" — never as an
 // "S" — no matter which side of the table you look from.
 
-import { getState } from "./state.js";
-import { computeMarks } from "./scoring.js";
+import { getState } from "./state.js?v=3";
+import { computeMarks } from "./scoring.js?v=3";
 
 // ── Board geometry (one half, local coordinates) ─────────────────
 const W = 640;        // board width

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -78,4 +78,4 @@ function computeMarks(entries) {
   return marks;
 }
 
-export { validatePoints, computeTotals, findWinner, decomposeEntry, computeMarks };
+export { validatePoints, computeTotals, findWinner, computeMarks };

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -52,8 +52,10 @@ function decomposeEntry(points) {
  * Accumulate chalk marks over the whole entry sequence — real chalk
  * semantics: each round is written once and its strokes stay on the
  * board forever. Marks are NEVER converted between lines (no
- * exchanging five twenties for a hundred); the rest numbers simply
- * add up.
+ * exchanging five twenties for a hundred). The sub-20 rests add up,
+ * but the written rest number must never reach 20: whenever the
+ * accumulated rest hits 20, a 20-mark is written on the bottom bar
+ * and the number is rewritten with what's left.
  */
 function computeMarks(entries) {
   const marks = {
@@ -68,6 +70,10 @@ function computeMarks(entries) {
     team.fifties += d.fifties;
     team.twenties += d.twenties;
     team.remainder += d.remainder;
+    while (team.remainder >= 20) {
+      team.remainder -= 20;
+      team.twenties += 1;
+    }
   }
   return marks;
 }

--- a/jass-scoreboard/js/state.js
+++ b/jass-scoreboard/js/state.js
@@ -1,7 +1,7 @@
 // state.js — global state definition, mutations, validation
 
-import { computeTotals, findWinner, validatePoints } from "./scoring.js";
-import { saveState } from "./storage.js";
+import { computeTotals, findWinner, validatePoints } from "./scoring.js?v=3";
+import { saveState } from "./storage.js?v=3";
 
 function defaults() {
   return {

--- a/jass-scoreboard/js/storage.js
+++ b/jass-scoreboard/js/storage.js
@@ -50,12 +50,4 @@ function migrateEntry(entry) {
   return { teamId: entry.teamId, points, timestamp: entry.timestamp || 0 };
 }
 
-function clearState() {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch (e) {
-    console.warn("Could not clear state:", e);
-  }
-}
-
-export { saveState, loadState, clearState };
+export { saveState, loadState };

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -9,8 +9,8 @@ import {
   resetGame,
   toggleFlip,
   acknowledgeWin
-} from "./state.js";
-import { render } from "./renderer.js";
+} from "./state.js?v=3";
+import { render } from "./renderer.js?v=3";
 
 let selectedTeam = "A";
 let errorTimeout = null;

--- a/jass-scoreboard/tests/.gitignore
+++ b/jass-scoreboard/tests/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+screenshots/

--- a/jass-scoreboard/tests/e2e.test.mjs
+++ b/jass-scoreboard/tests/e2e.test.mjs
@@ -148,6 +148,16 @@ try {
   check("reset keeps team name", stored.teams[0].name === "Huber & Meier");
   check("reset keeps target", stored.targetScore === 850, `got ${stored.targetScore}`);
 
+  // ── Rest number never reaches 20: carries into a 20-mark ──────────
+  await add("B", 19);
+  await add("B", 19); // rests 19+19=38 → one 20-mark + rest 18
+  nearB = await half(NEAR);
+  check("rest carries into a 20-mark at 20", nearB.marks === 1, `got ${nearB.marks} marks`);
+  check("rest number stays below 20", nearB.rest === "+ 18", `got ${nearB.rest}`);
+  await page.screenshot({ path: join(SHOTS_DIR, "rest-carry.png"), fullPage: true });
+  await page.click("#btn-undo");
+  await page.click("#btn-undo");
+
   // ── Injection-safe team names ─────────────────────────────────────
   await page.fill("#edit-name-a", "<img src=x onerror=alert(1)>");
   await page.locator("#edit-name-a").blur();

--- a/jass-scoreboard/tests/e2e.test.mjs
+++ b/jass-scoreboard/tests/e2e.test.mjs
@@ -1,0 +1,164 @@
+// e2e.test.mjs — Playwright end-to-end tests for the Jass scoreboard.
+//
+// Run:
+//   cd jass-scoreboard/tests && npm install && node e2e.test.mjs
+//
+// Spawns its own static server (python3 -m http.server) for the app and
+// drives real flows in Chromium. Exits non-zero if any check fails.
+// Screenshots land in tests/screenshots/ (gitignored).
+
+import { chromium } from "playwright";
+import { spawn } from "node:child_process";
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = join(TESTS_DIR, "..");
+const SHOTS_DIR = join(TESTS_DIR, "screenshots");
+const PORT = 8461;
+const URL = `http://localhost:${PORT}/index.html`;
+
+// Pre-installed Chromium (e.g. Claude Code remote env); falls back to
+// Playwright's own browser resolution.
+const CHROMIUM = process.env.CHROMIUM_PATH
+  || (existsSync("/opt/pw-browsers/chromium") ? "/opt/pw-browsers/chromium" : undefined);
+
+let failures = 0;
+function check(name, condition, detail = "") {
+  const ok = Boolean(condition);
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${ok || !detail ? "" : ` — ${detail}`}`);
+  if (!ok) failures++;
+}
+
+mkdirSync(SHOTS_DIR, { recursive: true });
+const server = spawn("python3", ["-m", "http.server", String(PORT)], {
+  cwd: APP_DIR,
+  stdio: "ignore"
+});
+await new Promise(r => setTimeout(r, 800));
+
+const browser = await chromium.launch({ executablePath: CHROMIUM });
+try {
+  const page = await browser.newPage({ viewport: { width: 430, height: 932 } });
+  const consoleErrors = [];
+  page.on("pageerror", e => consoleErrors.push("pageerror: " + e.message));
+  page.on("console", m => {
+    if (m.type() === "error" && !m.text().includes("favicon")) {
+      consoleErrors.push("console: " + m.text());
+    }
+  });
+  page.on("dialog", d => d.accept());
+
+  const add = async (team, pts) => {
+    await page.click(team === "A" ? "#btn-team-a" : "#btn-team-b");
+    await page.fill("#input-points", String(pts));
+    await page.click("#btn-add");
+  };
+  const half = async index =>
+    await page.evaluate(i => {
+      const g = document.querySelectorAll("#board svg > g")[i];
+      return {
+        marks: g.querySelectorAll("line.mark").length,
+        rest: g.querySelector("text.rest-num")?.textContent ?? null,
+        name: g.querySelector("text.team-name")?.textContent ?? null,
+        total: g.querySelector("text.team-total")?.textContent ?? null,
+        markXs: [...g.querySelectorAll("line.mark")].map(l => Math.round(+l.getAttribute("x1")))
+      };
+    }, index);
+  const FAR = 0, NEAR = 1;
+
+  await page.goto(URL);
+  await page.waitForSelector("#board svg");
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await page.waitForSelector("#board svg");
+
+  // ── Free entry + per-round chalk decomposition ────────────────────
+  await add("A", 157); // 1×100 + 1×50 + rest 7
+  await add("A", 257); // 2×100 + 1×50 + rest 7
+  let farA = await half(FAR);
+  check("free entry: total 157+257=414", farA.total === "414", `got ${farA.total}`);
+  check("marks per round: 3×100 + 2×50 = 5 strokes", farA.marks === 5, `got ${farA.marks}`);
+  check("rests accumulate: + 14", farA.rest === "+ 14", `got ${farA.rest}`);
+
+  // ── Validation ────────────────────────────────────────────────────
+  await page.fill("#input-points", "501");
+  await page.click("#btn-add");
+  const err = await page.locator("#error-msg").textContent();
+  check("validation: 501 rejected", err.includes("Maximal 500"), `got "${err}"`);
+
+  // ── Chalk semantics: no conversion, right-aligned 20s ─────────────
+  for (let i = 0; i < 5; i++) await add("B", 20);
+  let nearB = await half(NEAR);
+  // 5×20 (total 100) must stay on the 20-line as one complete bundle:
+  // 4 uprights + 1 slash = 5 stroke lines, and no 100-mark appears
+  check("no conversion: 5×20 → one ||||\\ bundle (5 lines)", nearB.marks === 5, `got ${nearB.marks}`);
+  const rightMost = Math.max(...nearB.markXs);
+  check("20s align right (near x=564)", rightMost > 540, `rightmost x=${rightMost}`);
+
+  // ── Bundling on all lines ─────────────────────────────────────────
+  for (let i = 0; i < 7; i++) await add("B", 50); // one bundle + 2 = 7 lines on diagonal
+  for (let i = 0; i < 4; i++) await add("A", 100); // A now 7×100: bundle(5) + 2 = 7 lines
+  nearB = await half(NEAR);
+  farA = await half(FAR);
+  check("50s bundle in fives (7×50 → 7 lines incl. slash)", nearB.marks === 5 + 7, `got ${nearB.marks}`);
+  check("100s bundle in fives (7×100 → 7 lines incl. slash)", farA.marks === 7 + 2, `A lines ${farA.marks} (7×100 + 2×50)`);
+  await page.screenshot({ path: join(SHOTS_DIR, "board.png"), fullPage: true });
+
+  // ── Undo removes exactly the last round's marks ───────────────────
+  const before = (await half(NEAR)).marks;
+  await add("B", 90); // writes 1×50 + 2×20
+  await page.click("#btn-undo");
+  nearB = await half(NEAR);
+  check("undo wipes only the last round's marks", nearB.marks === before, `got ${nearB.marks}, want ${before}`);
+
+  // ── Flip swaps halves, data unchanged ─────────────────────────────
+  const farNameBefore = (await half(FAR)).name;
+  await page.click("#btn-flip");
+  const farNameAfter = (await half(FAR)).name;
+  check("flip swaps far team", farNameBefore !== farNameAfter, `still ${farNameAfter}`);
+  await page.click("#btn-flip");
+
+  // ── Persistence across reload ─────────────────────────────────────
+  const totalBefore = (await half(FAR)).total;
+  await page.reload();
+  await page.waitForSelector("#board svg");
+  check("state survives reload", (await half(FAR)).total === totalBefore);
+
+  // ── Win: exceed target, entry disabled, undo revives ──────────────
+  // A is at 814, B at 450. Target 850 → adding 100 to A gives 914 > 850.
+  await page.fill("#input-target", "850");
+  await page.locator("#input-target").blur();
+  await add("A", 100);
+  const winVisible = await page.locator("#win-overlay.active").isVisible();
+  check("win overlay shows when total exceeds target", winVisible);
+  check("entry disabled after win", await page.locator("#btn-add").isDisabled());
+  await page.screenshot({ path: join(SHOTS_DIR, "win.png"), fullPage: true });
+  if (winVisible) await page.click("#win-overlay");
+  await page.click("#btn-undo"); // back to 814 < 850
+  check("undo revives a finished game", !(await page.locator("#btn-add").isDisabled()));
+
+  // ── Reset keeps names + target ────────────────────────────────────
+  await page.fill("#edit-name-a", "Huber & Meier");
+  await page.locator("#edit-name-a").blur();
+  await page.click("#btn-reset");
+  const stored = await page.evaluate(() => JSON.parse(localStorage.getItem("jassScoreboardState")));
+  check("reset clears entries", stored.entries.length === 0);
+  check("reset keeps team name", stored.teams[0].name === "Huber & Meier");
+  check("reset keeps target", stored.targetScore === 850, `got ${stored.targetScore}`);
+
+  // ── Injection-safe team names ─────────────────────────────────────
+  await page.fill("#edit-name-a", "<img src=x onerror=alert(1)>");
+  await page.locator("#edit-name-a").blur();
+  const injected = await page.locator("#board svg image, #board svg img").count();
+  check("team names are escaped in SVG", injected === 0);
+
+  check("no console errors", consoleErrors.length === 0, consoleErrors.join(" | "));
+} finally {
+  await browser.close();
+  server.kill();
+}
+
+console.log(failures === 0 ? "\nAll tests passed." : `\n${failures} test(s) FAILED.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/jass-scoreboard/tests/e2e.test.mjs
+++ b/jass-scoreboard/tests/e2e.test.mjs
@@ -9,7 +9,7 @@
 
 import { chromium } from "playwright";
 import { spawn } from "node:child_process";
-import { mkdirSync, existsSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +29,29 @@ function check(name, condition, detail = "") {
   const ok = Boolean(condition);
   console.log(`${ok ? "PASS" : "FAIL"}  ${name}${ok || !detail ? "" : ` — ${detail}`}`);
   if (!ok) failures++;
+}
+
+// ── Cache-busting version consistency ───────────────────────────────
+// Every local asset reference (index.html + inter-module imports) must
+// carry the same ?v= — a partial bump would serve mixed stale/new files.
+{
+  const sources = [
+    ["index.html", readFileSync(join(APP_DIR, "index.html"), "utf8")],
+    ...readdirSync(join(APP_DIR, "js"))
+      .filter(f => f.endsWith(".js"))
+      .map(f => [`js/${f}`, readFileSync(join(APP_DIR, "js", f), "utf8")])
+  ];
+  const versions = new Set();
+  let unversioned = [];
+  for (const [file, text] of sources) {
+    for (const m of text.matchAll(/(?:href="css\/[^"]+|src="js\/[^"]+|from "\.\/[^"]+)"/g)) {
+      const v = m[0].match(/\?v=([\w.]+)/);
+      if (v) versions.add(v[1]);
+      else unversioned.push(`${file}: ${m[0]}`);
+    }
+  }
+  check("all asset URLs carry a ?v= version", unversioned.length === 0, unversioned.join(" | "));
+  check("cache-busting version is identical everywhere", versions.size === 1, [...versions].join(", "));
 }
 
 mkdirSync(SHOTS_DIR, { recursive: true });

--- a/jass-scoreboard/tests/package.json
+++ b/jass-scoreboard/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "jass-scoreboard-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node e2e.test.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.49.0"
+  }
+}


### PR DESCRIPTION
Tests, spec hygiene and caching for the Jass scoreboard:

- **PRD is now a repo file** — [`jass-scoreboard/PRD.md`](https://github.com/LFDave/small-apps/blob/claude/jass-scoreboard-requirements-977knw/jass-scoreboard/PRD.md) (v2.2, cleaned/as-built) is the single source of truth; issue #6 is repointed there as historical reference. The README is now strictly user-facing (what it is, how to use/run/test) and no longer duplicates spec detail.
- **`jass-scoreboard/tests/`** — self-contained Playwright e2e suite (`npm install && node e2e.test.mjs`): spawns its own static server, 23 checks in Chromium covering entry, validation, chalk semantics (no conversion), right-aligned 20s, five-bundling on all lines, rest-carry, undo, flip, persistence, win, reset, SVG escaping, cache-version consistency, and zero console errors.
- **Rest number never reaches 20** — sub-20 rests add up, but at 20 a 20-mark is written and the number rewritten with the leftover (19 + 19 → one 20-mark and `+ 18`).
- **Mobile cache busting** — every local asset URL (CSS link, script tag, and every inter-module import) carries the same `?v=N`, bumped on release, so a plain reload always picks up changed JS/CSS. Two e2e checks fail the suite if any URL is unversioned or versions diverge.
- **Dead code removed** — unused `storage.clearState` and the unnecessary `decomposeEntry` export.
- **Inline SVG favicon** (data URI, chalk Z) — removes the favicon 404 console error.
- **CLAUDE.md** — standing rules: tests in `<app>/tests/` must pass before reporting; specs (PRD.md, README, app notes) updated in the same change as behavior; version bump procedure.

## Verification

Full suite run locally: **23/23 PASS**, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3