### PR TITLE
Split CLAUDE.md: repo-wide conventions vs per-app notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,29 +22,24 @@ For every UI change, before reporting back or opening/updating a PR:
    them with the summary. A change without a screenshot is not done.
 3. **Automated tests live in `<app>/tests/`.** Write or extend the
    Playwright e2e suite there for every behavior change, and run it —
-   it must pass before reporting back. For jass-scoreboard:
-   `cd jass-scoreboard/tests && npm install && node e2e.test.mjs`.
+   it must pass before reporting back.
 4. **Keep specs in sync.** Whenever behavior changes, update the spec in
    the same change so it always reflects reality. The PRD is a file in
-   the app folder (`jass-scoreboard/PRD.md`) and is the single source of
-   truth; the README is user-facing only (what it is, how to use/run/
-   test) and must not duplicate spec detail. Also update this file's app
+   the app folder (`<app>/PRD.md`) and is the single source of truth;
+   the README is user-facing only (what it is, how to use/run/test) and
+   must not duplicate spec detail. Also update the app's `CLAUDE.md`
    notes.
+
+## Repo-wide conventions
+
+- **Cache busting:** every local asset URL (CSS link, script tag, every
+  inter-module import) carries the same `?v=N` query. Bump N in ALL
+  files on every release so mobile browsers pick up changed JS/CSS on a
+  plain reload. Where an e2e suite exists it must enforce this
+  (jass-scoreboard's does).
 
 ## App notes
 
-### jass-scoreboard
-
-- Requirements PRD: `jass-scoreboard/PRD.md`. Module structure
-  (`state.js`, `storage.js`, `scoring.js`, `renderer.js`, `ui.js`,
-  `app.js`) is mandated by the PRD.
-- Cache busting: every local asset URL (CSS link, script tag, every
-  inter-module import) carries the same `?v=N`. Bump N in ALL files on
-  every release — the e2e suite fails on divergence.
-- The board is one SVG scene; each Z is point-symmetric so both Z's read
-  correctly from both sides of the table (far half rotated 180°).
-- Chalk semantics: marks are written per round and never converted
-  between lines (no exchanging five 20s for a 100); 20s align right on
-  the bottom bar; all lines bundle tallies in fives (`||||\`); only undo
-  removes the last round's marks. The rest number is always below 20 —
-  at 20 it carries into a 20-mark.
+App-specific instructions live in a `CLAUDE.md` inside the app's own
+folder (e.g. `jass-scoreboard/CLAUDE.md`) — it is loaded automatically
+when working on files in that directory, in addition to this file.

--- a/jass-scoreboard/CLAUDE.md
+++ b/jass-scoreboard/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md — jass-scoreboard
+
+App-specific guidance; the repo root `CLAUDE.md` (verification workflow,
+spec-sync rules, cache-busting convention) applies as well.
+
+- Requirements PRD: `PRD.md` in this folder — single source of truth,
+  updated in the same change as any behavior change. Module structure
+  (`state.js`, `storage.js`, `scoring.js`, `renderer.js`, `ui.js`,
+  `app.js`) is mandated by the PRD.
+- The board is one SVG scene; each Z is point-symmetric so both Z's read
+  correctly from both sides of the table (far half rotated 180°).
+- Chalk semantics: marks are written per round and never converted
+  between lines (no exchanging five 20s for a 100); 20s align right on
+  the bottom bar; all lines bundle tallies in fives (`||||\`); only undo
+  removes the last round's marks. The rest number is always below 20 —
+  at 20 it carries into a 20-mark.
+- Tests: `cd tests && npm install && node e2e.test.mjs` — must pass
+  before reporting back; it also enforces the `?v=N` cache-busting
+  consistency across index.html and all js imports.


### PR DESCRIPTION
Restructures the Claude instructions as discussed:

- **Root `CLAUDE.md`** keeps only what applies repo-wide: the verification workflow (now phrased generically, without jass-specific commands), the spec-sync rule (`<app>/PRD.md` as source of truth, README user-facing only), and a new **Repo-wide conventions** section holding the cache-busting rule (`?v=N` on every local asset URL, bumped everywhere per release).
- **`jass-scoreboard/CLAUDE.md`** (new) carries the app-specific notes moved out of the root file: PRD location + mandated module structure, the point-symmetric Z / both-sides readability design, the chalk semantics rules, and the concrete test command. Claude Code loads nested `CLAUDE.md` files automatically when working on files in that directory, in addition to the root one — so both apply, root globally and this one contextually.

Docs-only change — no app behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_