### PR TITLE
Jass scoreboard: negative-point corrections; Team A faces the device holder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A browser-based digital Jass scoreboard that replicates a traditional Swiss chal
 **Features:**
 - One SVG slate scene with two chalk Z's — both readable from both sides of the table (point-symmetric Z geometry, far half rotated 180°)
 - Classic Schieber chalk notation: 100s on the top bar, 50s on the diagonal, 20s right-aligned on the bottom bar — all bundled tally-style (`||||\`), rest as chalk number; marks stack up per round and are never converted (chalk stays chalk)
-- Free score entry (1–500) plus quick chips (+20/+50/+100/+157)
+- Free score entry (1–500) plus quick chips (+20/+50/+100/+157); negative entries correct mistakes (marks wiped highest → lowest)
 - Two teams, editable names and target score (default 2500)
 - Win detection with animated overlay (gold glow, chalk particles)
 - Undo last entry, reset game, rotate board orientation

--- a/jass-scoreboard/CLAUDE.md
+++ b/jass-scoreboard/CLAUDE.md
@@ -11,9 +11,12 @@ spec-sync rules, cache-busting convention) applies as well.
   correctly from both sides of the table (far half rotated 180°).
 - Chalk semantics: marks are written per round and never converted
   between lines (no exchanging five 20s for a 100); 20s align right on
-  the bottom bar; all lines bundle tallies in fives (`||||\`); only undo
-  removes the last round's marks. The rest number is always below 20 —
-  at 20 it carries into a 20-mark.
+  the bottom bar; all lines bundle tallies in fives (`||||\`); marks are
+  wiped only by undo (last round) or corrections (negative entries,
+  removing highest → lowest with borrowing). The rest number is always
+  below 20 — at 20 it carries into a 20-mark.
+- Team A defaults to the near (bottom) half — the side facing the person
+  holding the device.
 - Tests: `cd tests && npm install && node e2e.test.mjs` — must pass
   before reporting back; it also enforces the `?v=N` cache-busting
   consistency across index.html and all js imports.

--- a/jass-scoreboard/PRD.md
+++ b/jass-scoreboard/PRD.md
@@ -1,6 +1,6 @@
 # PRD — Digital Jass Scoreboard (Schiefertafel Z/Z)
 
-Version: 2.2 (as built — this file is the single source of truth and is
+Version: 2.3 (as built — this file is the single source of truth and is
 updated in the same change whenever behavior changes)
 
 ## 1. Product
@@ -69,8 +69,15 @@ Chalk marks are derived from the entry sequence, never stored.
 2. Enter points or tap a quick chip: +20 / +50 / +100 / +157
 3. **Eintragen** (Enter also submits)
 
-Validation: integer, `0 < points ≤ 500`. Errors shown in German in an
-`aria-live` region.
+Validation: integer, `-500 ≤ points ≤ 500`, not 0. Errors shown in
+German in an `aria-live` region.
+
+**Corrections:** negative points fix mistakes. A correction must not
+exceed the team's current total (rejected otherwise) and wipes marks
+from the **highest value down** — whole 100s first, then 50s, then 20s,
+as much as is needed; the leftover comes off the rest number. If the
+rest would go negative, the next-lowest available mark is wiped and the
+leftover rewritten as 20-marks + rest (chalk-writer style borrowing).
 
 ## 7. Chalk Mark Rendering
 
@@ -87,8 +94,8 @@ Hard rules (chalk semantics):
 
 - Marks accumulate round after round and are **never converted** between
   lines (no exchanging five 20s for a 100, or two 50s for a 100).
-- A written mark disappears only through **Undo**, which wipes exactly
-  the last round's marks.
+- A written mark disappears only through **Undo** (wipes exactly the
+  last round's marks) or a **correction** (negative entry, see §6).
 - All three lines bundle tallies in fives: every fifth stroke is a slash
   across the previous four (`||||\`) — display grouping, never conversion.
 - The rest number never reaches 20: rests add up, and at 20 a 20-mark is
@@ -107,6 +114,8 @@ Hard rules (chalk semantics):
   upside down is still a "Z", never an "S".
 - The far half is rotated 180° so that team's name, total and marks face
   the player across the table.
+- **Team A defaults to the near (bottom) half** — the side facing the
+  person holding the device; Team B to the far half.
 - The ⇅ button toggles `flipped`, swapping which team sits at the near
   edge; the data model never changes.
 

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -14,7 +14,9 @@ README only covers what it is and how to use it.
    `python3 -m http.server` → open `http://localhost:8000/index.html`
 2. Edit team names and the target score (default 2500) at the top.
 3. Select a team, type the round points (1–500) and hit **Eintragen** —
-   or tap a quick chip (+20 / +50 / +100 / +157).
+   or tap a quick chip (+20 / +50 / +100 / +157). Enter negative points
+   (e.g. -120) to correct a mistake: marks are wiped from the highest
+   value down. Team A is the half facing you; ⇅ swaps sides.
 4. **↩ Rückgängig** wipes the last round's marks, **🔄 Neu** starts a new
    game, **⇅** rotates the board for the players across the table.
 5. A team wins by *exceeding* the target. The game survives page

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -6,7 +6,7 @@
   <title>Jass Tafel — Schiefertafel Z/Z</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='18' fill='%23232e28'/%3E%3Cpath d='M25 32h50L25 68h50' stroke='%23f2efe4' stroke-width='9' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
   <!-- Cache busting: bump ?v= here AND in every js import on each release -->
-  <link rel="stylesheet" href="css/styles.css?v=3" />
+  <link rel="stylesheet" href="css/styles.css?v=4" />
 </head>
 <body>
   <!-- Win overlay -->
@@ -73,10 +73,10 @@
           id="input-points"
           type="number"
           inputmode="numeric"
-          min="1"
+          min="-500"
           max="500"
           placeholder="Punkte"
-          aria-label="Punkte eingeben (1 bis 500)"
+          aria-label="Punkte eingeben (-500 bis 500, negativ zur Korrektur)"
         />
         <button id="btn-add" class="btn btn-primary">Eintragen</button>
       </div>
@@ -95,6 +95,6 @@
     </div>
   </div>
 
-  <script type="module" src="js/app.js?v=3"></script>
+  <script type="module" src="js/app.js?v=4"></script>
 </body>
 </html>

--- a/jass-scoreboard/js/app.js
+++ b/jass-scoreboard/js/app.js
@@ -1,9 +1,9 @@
 // app.js — application bootstrap
 
-import { initState } from "./state.js?v=3";
-import { loadState } from "./storage.js?v=3";
-import { bindUI } from "./ui.js?v=3";
-import { render } from "./renderer.js?v=3";
+import { initState } from "./state.js?v=4";
+import { loadState } from "./storage.js?v=4";
+import { bindUI } from "./ui.js?v=4";
+import { render } from "./renderer.js?v=4";
 
 function bootstrap() {
   initState(loadState());

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -9,8 +9,8 @@
 // symmetry both Z shapes still read as a proper "Z" — never as an
 // "S" — no matter which side of the table you look from.
 
-import { getState } from "./state.js?v=3";
-import { computeMarks } from "./scoring.js?v=3";
+import { getState } from "./state.js?v=4";
+import { computeMarks } from "./scoring.js?v=4";
 
 // ── Board geometry (one half, local coordinates) ─────────────────
 const W = 640;        // board width
@@ -181,10 +181,11 @@ function buildHalf(team, total, marks, isWinner, seed) {
 function render() {
   const state = getState();
 
-  // flipped swaps which team sits at the near (bottom) edge;
-  // the data model itself never changes
-  const farTeam = state.flipped ? state.teams[1] : state.teams[0];
-  const nearTeam = state.flipped ? state.teams[0] : state.teams[1];
+  // Team A defaults to the near (bottom) half — the side facing the
+  // person holding the device; flipped swaps the halves. The data
+  // model itself never changes.
+  const nearTeam = state.flipped ? state.teams[1] : state.teams[0];
+  const farTeam = state.flipped ? state.teams[0] : state.teams[1];
   const marks = computeMarks(state.entries);
 
   const svg = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jasstafel: ${esc(farTeam.name)} ${state.totals[farTeam.id]} Punkte, ${esc(nearTeam.name)} ${state.totals[nearTeam.id]} Punkte">

--- a/jass-scoreboard/js/scoring.js
+++ b/jass-scoreboard/js/scoring.js
@@ -1,12 +1,13 @@
 // scoring.js — score validation, totals, win check, chalk-mark decomposition
 
 /**
- * Validate a round score. Returns an error message (German) or null if valid.
+ * Validate a round score. Negative values are corrections.
+ * Returns an error message (German) or null if valid.
  */
 function validatePoints(value) {
   if (!Number.isInteger(value)) return "Punkte müssen eine ganze Zahl sein.";
-  if (value < 1) return "Punkte müssen grösser als 0 sein.";
-  if (value > 500) return "Maximal 500 Punkte pro Eintrag.";
+  if (value === 0) return "Punkte dürfen nicht 0 sein.";
+  if (Math.abs(value) > 500) return "Maximal 500 Punkte pro Eintrag.";
   return null;
 }
 
@@ -49,13 +50,46 @@ function decomposeEntry(points) {
 }
 
 /**
+ * The written rest number must never reach 20: whenever the
+ * accumulated rest hits 20, a 20-mark is written on the bottom bar
+ * and the number is rewritten with what's left.
+ */
+function carryRest(team) {
+  while (team.remainder >= 20) {
+    team.remainder -= 20;
+    team.twenties += 1;
+  }
+}
+
+/**
+ * A correction (negative entry) wipes marks from the highest value
+ * down: whole 100s first, then 50s, then 20s, as much as is needed;
+ * what's left is taken off the rest number. If the rest would go
+ * negative, the next-lowest available mark is wiped and the leftover
+ * rewritten (as 20-marks + rest), like a chalk writer correcting the
+ * board.
+ */
+function removeMarks(team, amount) {
+  let need = amount;
+  while (need >= 100 && team.hundreds > 0) { team.hundreds--; need -= 100; }
+  while (need >= 50 && team.fifties > 0) { team.fifties--; need -= 50; }
+  while (need >= 20 && team.twenties > 0) { team.twenties--; need -= 20; }
+  team.remainder -= need;
+  while (team.remainder < 0) {
+    if (team.twenties > 0) { team.twenties--; team.remainder += 20; }
+    else if (team.fifties > 0) { team.fifties--; team.remainder += 50; }
+    else if (team.hundreds > 0) { team.hundreds--; team.remainder += 100; }
+    else { team.remainder = 0; break; } // guarded by total validation
+  }
+  carryRest(team);
+}
+
+/**
  * Accumulate chalk marks over the whole entry sequence — real chalk
  * semantics: each round is written once and its strokes stay on the
  * board forever. Marks are NEVER converted between lines (no
- * exchanging five twenties for a hundred). The sub-20 rests add up,
- * but the written rest number must never reach 20: whenever the
- * accumulated rest hits 20, a 20-mark is written on the bottom bar
- * and the number is rewritten with what's left.
+ * exchanging five twenties for a hundred). Corrections (negative
+ * entries) are the one sanctioned way marks get wiped besides undo.
  */
 function computeMarks(entries) {
   const marks = {
@@ -65,15 +99,16 @@ function computeMarks(entries) {
   for (const e of entries) {
     const team = marks[e.teamId];
     if (!team || !Number.isFinite(e.points)) continue;
+    if (e.points < 0) {
+      removeMarks(team, -e.points);
+      continue;
+    }
     const d = decomposeEntry(e.points);
     team.hundreds += d.hundreds;
     team.fifties += d.fifties;
     team.twenties += d.twenties;
     team.remainder += d.remainder;
-    while (team.remainder >= 20) {
-      team.remainder -= 20;
-      team.twenties += 1;
-    }
+    carryRest(team);
   }
   return marks;
 }

--- a/jass-scoreboard/js/state.js
+++ b/jass-scoreboard/js/state.js
@@ -1,7 +1,7 @@
 // state.js — global state definition, mutations, validation
 
-import { computeTotals, findWinner, validatePoints } from "./scoring.js?v=3";
-import { saveState } from "./storage.js?v=3";
+import { computeTotals, findWinner, validatePoints } from "./scoring.js?v=4";
+import { saveState } from "./storage.js?v=4";
 
 function defaults() {
   return {
@@ -79,6 +79,9 @@ function addEntry(teamId, points) {
   if (!state.teams.find(t => t.id === teamId)) return "Ungültiges Team.";
   const error = validatePoints(points);
   if (error) return error;
+  if (points < 0 && state.totals[teamId] + points < 0) {
+    return "Korrektur grösser als der aktuelle Punktestand.";
+  }
   state.entries.push({ teamId, points, timestamp: Date.now() });
   recompute();
   saveState(state);

--- a/jass-scoreboard/js/storage.js
+++ b/jass-scoreboard/js/storage.js
@@ -44,9 +44,9 @@ function loadState() {
 function migrateEntry(entry) {
   if (!entry || (entry.teamId !== "A" && entry.teamId !== "B")) return null;
   let points = null;
-  if (Number.isInteger(entry.points) && entry.points >= 1) points = entry.points;
+  if (Number.isInteger(entry.points) && entry.points !== 0) points = entry.points;
   else if (Number.isInteger(entry.value) && entry.value >= 1) points = entry.value;
-  if (points === null || points > 500) return null;
+  if (points === null || Math.abs(points) > 500) return null;
   return { teamId: entry.teamId, points, timestamp: entry.timestamp || 0 };
 }
 

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -9,8 +9,8 @@ import {
   resetGame,
   toggleFlip,
   acknowledgeWin
-} from "./state.js?v=3";
-import { render } from "./renderer.js?v=3";
+} from "./state.js?v=4";
+import { render } from "./renderer.js?v=4";
 
 let selectedTeam = "A";
 let errorTimeout = null;

--- a/jass-scoreboard/tests/e2e.test.mjs
+++ b/jass-scoreboard/tests/e2e.test.mjs
@@ -97,13 +97,16 @@ try {
   await page.reload();
   await page.waitForSelector("#board svg");
 
+  // ── Team A faces the device holder (near/bottom half) ─────────────
+  check("Team A sits at the near half by default", (await half(NEAR)).name === "Team A");
+
   // ── Free entry + per-round chalk decomposition ────────────────────
   await add("A", 157); // 1×100 + 1×50 + rest 7
   await add("A", 257); // 2×100 + 1×50 + rest 7
-  let farA = await half(FAR);
-  check("free entry: total 157+257=414", farA.total === "414", `got ${farA.total}`);
-  check("marks per round: 3×100 + 2×50 = 5 strokes", farA.marks === 5, `got ${farA.marks}`);
-  check("rests accumulate: + 14", farA.rest === "+ 14", `got ${farA.rest}`);
+  let nearA = await half(NEAR);
+  check("free entry: total 157+257=414", nearA.total === "414", `got ${nearA.total}`);
+  check("marks per round: 3×100 + 2×50 = 5 strokes", nearA.marks === 5, `got ${nearA.marks}`);
+  check("rests accumulate: + 14", nearA.rest === "+ 14", `got ${nearA.rest}`);
 
   // ── Validation ────────────────────────────────────────────────────
   await page.fill("#input-points", "501");
@@ -113,28 +116,28 @@ try {
 
   // ── Chalk semantics: no conversion, right-aligned 20s ─────────────
   for (let i = 0; i < 5; i++) await add("B", 20);
-  let nearB = await half(NEAR);
+  let farB = await half(FAR);
   // 5×20 (total 100) must stay on the 20-line as one complete bundle:
   // 4 uprights + 1 slash = 5 stroke lines, and no 100-mark appears
-  check("no conversion: 5×20 → one ||||\\ bundle (5 lines)", nearB.marks === 5, `got ${nearB.marks}`);
-  const rightMost = Math.max(...nearB.markXs);
+  check("no conversion: 5×20 → one ||||\\ bundle (5 lines)", farB.marks === 5, `got ${farB.marks}`);
+  const rightMost = Math.max(...farB.markXs); // local coords, unaffected by the half's rotation
   check("20s align right (near x=564)", rightMost > 540, `rightmost x=${rightMost}`);
 
   // ── Bundling on all lines ─────────────────────────────────────────
   for (let i = 0; i < 7; i++) await add("B", 50); // one bundle + 2 = 7 lines on diagonal
   for (let i = 0; i < 4; i++) await add("A", 100); // A now 7×100: bundle(5) + 2 = 7 lines
-  nearB = await half(NEAR);
-  farA = await half(FAR);
-  check("50s bundle in fives (7×50 → 7 lines incl. slash)", nearB.marks === 5 + 7, `got ${nearB.marks}`);
-  check("100s bundle in fives (7×100 → 7 lines incl. slash)", farA.marks === 7 + 2, `A lines ${farA.marks} (7×100 + 2×50)`);
+  farB = await half(FAR);
+  nearA = await half(NEAR);
+  check("50s bundle in fives (7×50 → 7 lines incl. slash)", farB.marks === 5 + 7, `got ${farB.marks}`);
+  check("100s bundle in fives (7×100 → 7 lines incl. slash)", nearA.marks === 7 + 2, `A lines ${nearA.marks} (7×100 + 2×50)`);
   await page.screenshot({ path: join(SHOTS_DIR, "board.png"), fullPage: true });
 
   // ── Undo removes exactly the last round's marks ───────────────────
-  const before = (await half(NEAR)).marks;
+  const before = (await half(FAR)).marks;
   await add("B", 90); // writes 1×50 + 2×20
   await page.click("#btn-undo");
-  nearB = await half(NEAR);
-  check("undo wipes only the last round's marks", nearB.marks === before, `got ${nearB.marks}, want ${before}`);
+  farB = await half(FAR);
+  check("undo wipes only the last round's marks", farB.marks === before, `got ${farB.marks}, want ${before}`);
 
   // ── Flip swaps halves, data unchanged ─────────────────────────────
   const farNameBefore = (await half(FAR)).name;
@@ -174,10 +177,31 @@ try {
   // ── Rest number never reaches 20: carries into a 20-mark ──────────
   await add("B", 19);
   await add("B", 19); // rests 19+19=38 → one 20-mark + rest 18
-  nearB = await half(NEAR);
-  check("rest carries into a 20-mark at 20", nearB.marks === 1, `got ${nearB.marks} marks`);
-  check("rest number stays below 20", nearB.rest === "+ 18", `got ${nearB.rest}`);
+  farB = await half(FAR);
+  check("rest carries into a 20-mark at 20", farB.marks === 1, `got ${farB.marks} marks`);
+  check("rest number stays below 20", farB.rest === "+ 18", `got ${farB.rest}`);
   await page.screenshot({ path: join(SHOTS_DIR, "rest-carry.png"), fullPage: true });
+  await page.click("#btn-undo");
+  await page.click("#btn-undo");
+
+  // ── Corrections: negative points wipe marks highest → lowest ──────
+  await add("A", 180); // marks {1×100, 1×50, 1×20, +10}
+  await add("A", -120); // wipes the 100 and the 20 → {1×50, +10}, total 60
+  nearA = await half(NEAR);
+  check("correction removes highest→lowest (180−120 → 1×50 + 10)",
+    nearA.total === "60" && nearA.marks === 1 && nearA.rest === "+ 10",
+    `total ${nearA.total}, marks ${nearA.marks}, rest ${nearA.rest}`);
+  await add("A", -30); // 60−30: wipes the 50, rewrites 1×20 + 10
+  nearA = await half(NEAR);
+  check("correction borrows from a higher mark and rewrites",
+    nearA.total === "30" && nearA.marks === 1 && nearA.rest === "+ 10",
+    `total ${nearA.total}, marks ${nearA.marks}, rest ${nearA.rest}`);
+  await page.screenshot({ path: join(SHOTS_DIR, "correction.png"), fullPage: true });
+  await add("A", -100); // more than the current total → rejected
+  const corrErr = await page.locator("#error-msg").textContent();
+  check("correction larger than total is rejected", corrErr.includes("Korrektur"), `got "${corrErr}"`);
+  check("rejected correction changes nothing", (await half(NEAR)).total === "30");
+  await page.click("#btn-undo");
   await page.click("#btn-undo");
   await page.click("#btn-undo");
 


### PR DESCRIPTION
Two behavior changes:

## Corrections via negative points

Entering a negative value (down to −500) corrects a mistake. The correction wipes marks from the **highest value down**: whole 100s first, then 50s, then 20s, as much as is needed; the leftover comes off the rest number. If the rest would go negative, the next-lowest available mark is wiped and the leftover rewritten as 20-marks + rest — chalk-writer-style borrowing. Examples:

- 180 on the board (1×100, 1×50, 1×20, `+ 10`) − 120 → the 100 and the 20 are wiped: 1×50, `+ 10` (total 60)
- 60 (1×50, `+ 10`) − 30 → the 50 is wiped and rewritten: 1×20, `+ 10` (total 30)

A correction larger than the team's current total is rejected ("Korrektur grösser als der aktuelle Punktestand."). Zero is no longer a valid entry; legacy-entry migration accepts negatives.

## Team A at the near edge

Team A now defaults to the **near (bottom) half** — the side facing the person holding the device; Team B is across the table. ⇅ still swaps sides without touching the data.

## Housekeeping

- Cache version bumped to `?v=4` in index.html and every module import (per repo convention)
- Specs synced in the same change: PRD → v2.3, app README, root README, `jass-scoreboard/CLAUDE.md`

## Verification

e2e suite extended to **28 checks — all passing** (new: Team A near-half default, highest→lowest removal, borrow-and-rewrite, over-correction rejection with unchanged board), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_