### PR TITLE
Jass scoreboard: JPG export of the board (both Z's, no controls)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,12 @@ For every UI change, before reporting back or opening/updating a PR:
    the README is user-facing only (what it is, how to use/run/test) and
    must not duplicate spec detail. Also update the app's `CLAUDE.md`
    notes.
+5. **Always post a fresh live link.** When reporting back, include a
+   direct link to the deployed app on GitHub Pages with a unique `?r=`
+   cache-buster so the user never hits stale cached HTML, e.g.
+   `https://lfdave.github.io/small-apps/jass-scoreboard/index.html?r=YYYYMMDD-N`
+   (any unique value works; the app ignores the query). Note the change
+   is only live once the PR is merged and Pages has redeployed.
 
 ## Repo-wide conventions
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A browser-based digital Jass scoreboard that replicates a traditional Swiss chal
 - Two teams, editable names and target score (default 2500)
 - Win detection with animated overlay (gold glow, chalk particles)
 - Undo last entry, reset game, rotate board orientation
+- JPG export of the board (just the two Z's, no controls)
 - Game state persisted to localStorage — resume on page reload
 - Responsive: works on mobile (320px+), tablet, and desktop
 - No external frameworks — pure HTML, CSS, Vanilla JS

--- a/jass-scoreboard/CLAUDE.md
+++ b/jass-scoreboard/CLAUDE.md
@@ -17,6 +17,9 @@ spec-sync rules, cache-busting convention) applies as well.
   below 20 — at 20 it carries into a 20-mark.
 - Team A defaults to the near (bottom) half — the side facing the person
   holding the device.
+- JPG export builds a standalone SVG with styles inlined via
+  `EXPORT_STYLE` in renderer.js — keep that block in sync with the same
+  classes in css/styles.css when changing board styling.
 - Tests: `cd tests && npm install && node e2e.test.mjs` — must pass
   before reporting back; it also enforces the `?v=N` cache-busting
   consistency across index.html and all js imports.

--- a/jass-scoreboard/PRD.md
+++ b/jass-scoreboard/PRD.md
@@ -1,6 +1,6 @@
 # PRD — Digital Jass Scoreboard (Schiefertafel Z/Z)
 
-Version: 2.3 (as built — this file is the single source of truth and is
+Version: 2.4 (as built — this file is the single source of truth and is
 updated in the same change whenever behavior changes)
 
 ## 1. Product
@@ -119,6 +119,17 @@ Hard rules (chalk semantics):
 - The ⇅ button toggles `flipped`, swapping which team sits at the near
   edge; the data model never changes.
 
+## 8a. Export
+
+The 📷 button saves the board as a **JPG** download
+(`jasstafel-YYYY-MM-DD.jpg`): just the slate with the two Z's, names,
+totals and marks — no controls. Implementation: the board SVG is made
+self-contained (explicit size, inlined styles, slate background),
+rasterized onto a 2× canvas and downloaded via `canvas.toBlob` — pure
+browser APIs. PDF export is deliberately not offered: it would require
+an external library (forbidden by §2); the browser's print dialog can
+produce a PDF. Export stays available after a win.
+
 ## 9. Undo & Reset
 
 - Undo: `entries.pop()` → recompute totals/marks/winner → re-render.
@@ -162,4 +173,4 @@ Hard rules (chalk semantics):
 ## 13. Out of Scope
 
 Multiple Jass variants, multiplayer sync, PWA install, statistics,
-export screenshot, tournament mode.
+PDF export, tournament mode.

--- a/jass-scoreboard/README.md
+++ b/jass-scoreboard/README.md
@@ -21,6 +21,8 @@ README only covers what it is and how to use it.
    game, **⇅** rotates the board for the players across the table.
 5. A team wins by *exceeding* the target. The game survives page
    reloads (localStorage).
+6. **📷** saves the board (just the two Z's, no controls) as a JPG
+   image — e.g. to share the final result.
 
 Rounds are written as chalk marks like on a real Jasstafel: 100s on the
 top bar, 50s on the diagonal, 20s right-aligned on the bottom bar (all

--- a/jass-scoreboard/index.html
+++ b/jass-scoreboard/index.html
@@ -6,7 +6,7 @@
   <title>Jass Tafel — Schiefertafel Z/Z</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect width='100' height='100' rx='18' fill='%23232e28'/%3E%3Cpath d='M25 32h50L25 68h50' stroke='%23f2efe4' stroke-width='9' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E" />
   <!-- Cache busting: bump ?v= here AND in every js import on each release -->
-  <link rel="stylesheet" href="css/styles.css?v=4" />
+  <link rel="stylesheet" href="css/styles.css?v=5" />
 </head>
 <body>
   <!-- Win overlay -->
@@ -40,6 +40,7 @@
           aria-label="Zielpunktzahl"
         />
         <button id="btn-flip" class="btn btn-icon" title="Tafel drehen" aria-label="Tafel drehen — Teamseiten tauschen">⇅</button>
+        <button id="btn-export" class="btn btn-icon" title="Als Bild speichern" aria-label="Tafel als JPG-Bild speichern">📷</button>
       </div>
     </header>
 
@@ -95,6 +96,6 @@
     </div>
   </div>
 
-  <script type="module" src="js/app.js?v=4"></script>
+  <script type="module" src="js/app.js?v=5"></script>
 </body>
 </html>

--- a/jass-scoreboard/js/app.js
+++ b/jass-scoreboard/js/app.js
@@ -1,9 +1,9 @@
 // app.js — application bootstrap
 
-import { initState } from "./state.js?v=4";
-import { loadState } from "./storage.js?v=4";
-import { bindUI } from "./ui.js?v=4";
-import { render } from "./renderer.js?v=4";
+import { initState } from "./state.js?v=5";
+import { loadState } from "./storage.js?v=5";
+import { bindUI } from "./ui.js?v=5";
+import { render } from "./renderer.js?v=5";
 
 function bootstrap() {
   initState(loadState());

--- a/jass-scoreboard/js/renderer.js
+++ b/jass-scoreboard/js/renderer.js
@@ -9,8 +9,8 @@
 // symmetry both Z shapes still read as a proper "Z" — never as an
 // "S" — no matter which side of the table you look from.
 
-import { getState } from "./state.js?v=4";
-import { computeMarks } from "./scoring.js?v=4";
+import { getState } from "./state.js?v=5";
+import { computeMarks } from "./scoring.js?v=5";
 
 // ── Board geometry (one half, local coordinates) ─────────────────
 const W = 640;        // board width
@@ -178,7 +178,28 @@ function buildHalf(team, total, marks, isWinner, seed) {
   return s;
 }
 
-function render() {
+// Styles inlined into the standalone export SVG — the app stylesheet
+// doesn't apply once the SVG leaves the page. Keep in sync with the
+// same classes in css/styles.css.
+const EXPORT_STYLE = `
+  .board-frame{fill:none;stroke:rgba(216,74,67,0.35);stroke-width:2.5}
+  .board-divider{stroke:#d84a43;stroke-width:3.5;stroke-linecap:round;opacity:.85}
+  .z-line{stroke:#d84a43;stroke-width:4;stroke-linecap:round;opacity:.85}
+  .z-diag{stroke-width:3;opacity:.7}
+  .line-label{fill:rgba(216,74,67,0.55);font-family:'Segoe Print','Bradley Hand','Chalkboard SE','Comic Sans MS',cursive;font-size:15px}
+  .mark{stroke:#f2efe4;opacity:.92}
+  .team-name{fill:#f2efe4;font-family:'Segoe Print','Bradley Hand','Chalkboard SE','Comic Sans MS',cursive;font-size:27px}
+  .team-total{fill:#f2efe4;font-family:'Segoe Print','Bradley Hand','Chalkboard SE','Comic Sans MS',cursive;font-size:46px;font-weight:700}
+  .rest-num{fill:#f2efe4;font-family:'Segoe Print','Bradley Hand','Chalkboard SE','Comic Sans MS',cursive;font-size:28px}
+  .win-glow{fill:rgba(255,215,90,0.09);stroke:#ffd75a;stroke-width:2.5}
+`;
+
+/**
+ * The complete slate scene (both Z's, no controls). With forExport the
+ * SVG is self-contained: explicit size, inlined styles and a slate
+ * background, so it rasterizes correctly outside the page.
+ */
+function buildBoardSvg(forExport = false) {
   const state = getState();
 
   // Team A defaults to the near (bottom) half — the side facing the
@@ -188,21 +209,39 @@ function render() {
   const farTeam = state.flipped ? state.teams[0] : state.teams[1];
   const marks = computeMarks(state.entries);
 
-  const svg = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jasstafel: ${esc(farTeam.name)} ${state.totals[farTeam.id]} Punkte, ${esc(nearTeam.name)} ${state.totals[nearTeam.id]} Punkte">
+  const sizeAttrs = forExport ? ` width="${W}" height="${H}"` : "";
+  const exportBits = forExport
+    ? `<style>${EXPORT_STYLE}</style>
+       <rect width="${W}" height="${H}" rx="12" fill="url(#slate-grad)"/>`
+    : "";
+  const gradientDef = forExport
+    ? `<linearGradient id="slate-grad" x1="0" y1="0" x2="0.34" y2="0.94">
+         <stop offset="0" stop-color="#232e28"/>
+         <stop offset="1" stop-color="#1b241f"/>
+       </linearGradient>`
+    : "";
+
+  return `<svg viewBox="0 0 ${W} ${H}"${sizeAttrs} xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jasstafel: ${esc(farTeam.name)} ${state.totals[farTeam.id]} Punkte, ${esc(nearTeam.name)} ${state.totals[nearTeam.id]} Punkte">
     <defs>
       <filter id="chalk-rough" x="-5%" y="-5%" width="110%" height="110%">
         <feTurbulence type="fractalNoise" baseFrequency="0.6" numOctaves="2" result="noise"/>
         <feDisplacementMap in="SourceGraphic" in2="noise" scale="2.4"/>
       </filter>
+      ${gradientDef}
     </defs>
+    ${exportBits}
     <rect class="board-frame" x="10" y="10" width="${W - 20}" height="${H - 20}" rx="16"/>
     <g transform="rotate(180 ${W / 2} ${HH / 2})">${buildHalf(farTeam, state.totals[farTeam.id], marks[farTeam.id], state.winner === farTeam.id, 11)}</g>
     <line class="board-divider" x1="26" y1="${HH}" x2="${W - 26}" y2="${HH}"/>
     <g transform="translate(0 ${HH})">${buildHalf(nearTeam, state.totals[nearTeam.id], marks[nearTeam.id], state.winner === nearTeam.id, 47)}</g>
   </svg>`;
+}
+
+function render() {
+  const state = getState();
 
   const board = document.getElementById("board");
-  if (board) board.innerHTML = svg;
+  if (board) board.innerHTML = buildBoardSvg();
 
   // Team toggle labels
   const btnTeamA = document.getElementById("btn-team-a");
@@ -242,4 +281,4 @@ function renderWinOverlay(state) {
   }
 }
 
-export { render };
+export { render, buildBoardSvg };

--- a/jass-scoreboard/js/state.js
+++ b/jass-scoreboard/js/state.js
@@ -1,7 +1,7 @@
 // state.js — global state definition, mutations, validation
 
-import { computeTotals, findWinner, validatePoints } from "./scoring.js?v=4";
-import { saveState } from "./storage.js?v=4";
+import { computeTotals, findWinner, validatePoints } from "./scoring.js?v=5";
+import { saveState } from "./storage.js?v=5";
 
 function defaults() {
   return {

--- a/jass-scoreboard/js/ui.js
+++ b/jass-scoreboard/js/ui.js
@@ -9,8 +9,8 @@ import {
   resetGame,
   toggleFlip,
   acknowledgeWin
-} from "./state.js?v=4";
-import { render } from "./renderer.js?v=4";
+} from "./state.js?v=5";
+import { render, buildBoardSvg } from "./renderer.js?v=5";
 
 let selectedTeam = "A";
 let errorTimeout = null;
@@ -49,6 +49,9 @@ function bindUI() {
     toggleFlip();
     render();
   });
+
+  // Export the slate (both Z's, no controls) as a JPG download
+  document.getElementById("btn-export")?.addEventListener("click", exportBoardAsJpg);
 
   // Team names
   bindNameInput("edit-name-a", "A");
@@ -111,6 +114,47 @@ function recordScore(points) {
   }
   render();
   return true;
+}
+
+/**
+ * Rasterize the self-contained board SVG onto a 2× canvas and trigger
+ * a JPG download (jasstafel-YYYY-MM-DD.jpg). Pure browser APIs — a PDF
+ * export would require an external library, which this app forbids;
+ * the browser's print dialog can produce a PDF instead.
+ */
+function exportBoardAsJpg() {
+  const svgMarkup = buildBoardSvg(true);
+  const svgUrl = URL.createObjectURL(new Blob([svgMarkup], { type: "image/svg+xml;charset=utf-8" }));
+  const img = new Image();
+  img.onload = () => {
+    URL.revokeObjectURL(svgUrl);
+    const scale = 2;
+    const canvas = document.createElement("canvas");
+    canvas.width = 640 * scale;
+    canvas.height = 920 * scale;
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#232e28";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob(blob => {
+      if (!blob) {
+        showError("Export fehlgeschlagen.");
+        return;
+      }
+      const link = document.createElement("a");
+      link.href = URL.createObjectURL(blob);
+      const d = new Date();
+      const pad = n => String(n).padStart(2, "0");
+      link.download = `jasstafel-${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}.jpg`;
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(link.href), 1000);
+    }, "image/jpeg", 0.92);
+  };
+  img.onerror = () => {
+    URL.revokeObjectURL(svgUrl);
+    showError("Export fehlgeschlagen.");
+  };
+  img.src = svgUrl;
 }
 
 function showError(msg) {

--- a/jass-scoreboard/tests/e2e.test.mjs
+++ b/jass-scoreboard/tests/e2e.test.mjs
@@ -197,6 +197,20 @@ try {
     nearA.total === "30" && nearA.marks === 1 && nearA.rest === "+ 10",
     `total ${nearA.total}, marks ${nearA.marks}, rest ${nearA.rest}`);
   await page.screenshot({ path: join(SHOTS_DIR, "correction.png"), fullPage: true });
+
+  // ── JPG export of the board (both Z's, no controls) ───────────────
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.click("#btn-export")
+  ]);
+  check("export downloads jasstafel-YYYY-MM-DD.jpg",
+    /^jasstafel-\d{4}-\d{2}-\d{2}\.jpg$/.test(download.suggestedFilename()),
+    `got ${download.suggestedFilename()}`);
+  await download.saveAs(join(SHOTS_DIR, "export.jpg"));
+  const jpg = readFileSync(join(SHOTS_DIR, "export.jpg"));
+  check("export is a real JPEG with content",
+    jpg.length > 20000 && jpg[0] === 0xff && jpg[1] === 0xd8,
+    `${jpg.length} bytes, magic ${jpg[0]?.toString(16)}${jpg[1]?.toString(16)}`);
   await add("A", -100); // more than the current total → rejected
   const corrErr = await page.locator("#error-msg").textContent();
   check("correction larger than total is rejected", corrErr.includes("Korrektur"), `got "${corrErr}"`);


### PR DESCRIPTION
Adds a 📷 button in the header that downloads the current board as **`jasstafel-YYYY-MM-DD.jpg`** — just the slate scene (both Z's, names, totals, marks), no controls, rendered at 2× resolution.

**Why JPG and not PDF:** JPG is achievable with pure browser APIs — the board SVG is made self-contained (explicit size, inlined styles via `EXPORT_STYLE`, slate gradient background, since the page stylesheet doesn't apply to a standalone SVG), rasterized onto a canvas and downloaded via `canvas.toBlob`. A PDF export would require an external library, which the app's constraints forbid; the browser's print dialog can produce a PDF if ever needed. Export stays available after a win, so the final result can be saved.

Housekeeping per repo conventions: cache version bumped to `?v=5` everywhere; specs synced (PRD → v2.4 with new §8a Export, app README, root README, `jass-scoreboard/CLAUDE.md` gains an `EXPORT_STYLE`-sync note).

## Verification

e2e suite now at **30 checks — all passing**: the new tests click the export button, verify the download filename pattern, and validate the file is a real JPEG (magic bytes + size). The exported artifact was also inspected visually.

*(Note: this commit was originally pushed to the PR #15 branch moments after that PR merged, so it was rebased onto main and gets its own PR here.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3

---
_Generated by [Claude Code](https://claude.ai/code/session_018NwJipkwAMjjMDcuGHfZy3)_