### PR TITLE
Rechenweg hints and a progress reset for the Mathe-Trainer

### DIFF
--- a/add-subtract/CLAUDE.md
+++ b/add-subtract/CLAUDE.md
@@ -4,4 +4,7 @@
 - Single-file app: all CSS and JS live inline in index.html. The only local asset is favicon.svg, which carries the `?v=N` cache buster.
 - The answer input implements the known-length input pattern from PRODUCT.md. Never add a confirm button to it and never add auto-advance timers.
 - The progression layer (XP, levels, medals, difficulty proposal) follows GAMIFICATION.md. Medal checks are pure functions of the stats object; never add event flags. Rewards render only in the post-task block, never during input.
+- Hints (`plusHint` and `minusHint`) are pure functions of the two operands. Two rules hold for every branch: the steps must be arithmetically true, and exactly the last step stays open with "?", so the hint never writes out the solved task. When you touch a branch, check the whole table in PRD.md again, including custom ranges up to 1000.
+- A hint is free. It never costs XP and never blocks a medal. It only keeps the task out of the clean-run streak behind the difficulty proposal.
+- "Alles zurücksetzen" belongs in the home footer with its confirm, per PRODUCT.md. It clears `add-subtract.stats` and keeps `add-subtract.settings`.
 - PRD.md in this folder is the single source of truth for behavior. Update it in the same change as any behavior change, and keep the e2e suite in tests/ passing.

--- a/add-subtract/PRD.md
+++ b/add-subtract/PRD.md
@@ -1,6 +1,6 @@
 # Mathe-Trainer (add-subtract) PRD
 
-Version: 2026-08-01. Single source of truth for behavior.
+Version: 2026-08-03. Single source of truth for behavior.
 
 ## Task
 
@@ -13,6 +13,12 @@ Practice addition and subtraction. German UI, dark theme, sage accent, no accoun
 - Invalid custom range shows an inline German message in a role="status" element. No alert().
 - "Los geht's" saves settings to localStorage `add-subtract.settings` and starts the quiz.
 - Last used settings are restored on load.
+- Home footer, below "Los geht's" and separated by a hairline: the storage note "Fortschritt und Einstellungen bleiben auf diesem Gerät." and the link-styled button "Alles zurücksetzen".
+  - Reset asks first with a native confirm that names what goes and where the data lives: "Allen Fortschritt löschen? XP, Medaillen und gelöste Aufgaben verschwinden. Die Daten liegen nur auf diesem Gerät."
+  - Cancelling changes nothing. Confirming clears `add-subtract.stats` back to zero, so XP, level, streak, solve counters and every medal reset together.
+  - Settings survive the reset. A child practising minus up to 100 should not land back on plus up to 10.
+  - The stats strip and the medal count re-render at once, and a `role="status"` line under the button says "Der Fortschritt wurde gelöscht. Die Einstellungen bleiben." It clears when the home screen is left.
+  - Reset stays in the home footer, never in the quiz.
 
 ## Quiz screen
 
@@ -22,6 +28,7 @@ Practice addition and subtraction. German UI, dark theme, sage accent, no accoun
 - Answer input follows the known-length input pattern from PRODUCT.md:
   - One slot per digit of the correct answer; digit count is visible.
   - On-screen keypad 0-9 plus backspace; physical digit keys, Backspace, and Enter also work.
+  - Enter on a focused button does that button's job and nothing else. Only with focus outside a button does Enter advance from "Weiter" or decline a proposal, so one keypress never triggers two actions.
   - The answer auto-checks the moment the last digit is entered. There is no confirm button.
   - The whole answer is evaluated, never single digits while typing.
   - Advisory text under the slots: "Bei der letzten Ziffer siehst du sofort, ob es stimmt." (WCAG 3.2.2)
@@ -29,9 +36,42 @@ Practice addition and subtraction. German UI, dark theme, sage accent, no accoun
   - No delays or hidden timing around evaluation (WCAG 2.2.1).
 - Correct: slots lock with success styling, feedback "Richtig. a op b = x.", solved and streak counters increment and persist to `add-subtract.stats`, "Weiter" button appears and takes focus. Advancing is always this deliberate action; there is no auto-advance.
 - Wrong, attempt 1: wrong positions get danger styling, feedback "Fast. Versuch es noch einmal." Correction via backspace; marks clear on edit.
-- Wrong, attempt 2: same, plus counting hint ("Beginne bei X und zähle Y weiter/zurück.").
+- Wrong, attempt 2: same, and the Rechenweg opens by itself, feedback "Fast. Der Rechenweg unter der Aufgabe hilft dir weiter."
 - Wrong, attempt 3: the correct answer is revealed in the slots, feedback names the solution, streak resets to 0, "Weiter" appears. No harsh language.
 - Toolbar: "Richtig: N · Serie: M" (tabular numerals) and an "Ändern" button back to setup.
+
+## Rechenweg
+
+A hint shows how to get to the answer, not the answer itself.
+
+- The quiz has a "Rechenweg zeigen" toggle under the advisory line, with a Lucide `lightbulb` icon, `aria-expanded` and `aria-controls="hint"`. Pressing it again collapses the block and the label switches to "Rechenweg ausblenden".
+- The hint block sits between the toggle and the keypad and is a `role="status"` region, so opening it is announced. It holds a title naming the strategy, the steps as an unnumbered ordered list, and an optional short note.
+- Every hint breaks the task into steps small enough to do in the head and leaves exactly the last one open with "?", so the learner still makes the closing move. A hint never writes out the solved task.
+- The hint stays until "Weiter" and stays available after the task is solved.
+- The strategy follows from the numbers of the current task:
+
+| Task shape | Strategy | Example |
+| --- | --- | --- |
+| plus, one part 0 | nothing changes | 7 + 0 |
+| plus, small part crosses a ten | fill up to the ten | 8 + 7 → 8 + 2 = 10, 10 + 5 = ? |
+| plus, small part lands on the ten | named, no steps | 5 + 5 |
+| plus, both parts under ten, no crossing | count on from the larger part | 3 + 4 |
+| plus, no crossing, tens present | ones only, the tens stay | 45 + 3 → 5 + 3 = ? |
+| plus, both parts whole tens | tens only, then a zero | 40 + 20 → 4 + 2 = ? |
+| plus, second part a whole ten | split the other number | 23 + 40 → 40 + 20 = 60, 60 + 3 = ? |
+| plus, two parts of ten or more | split the smaller into tens and ones | 23 + 45 → 45 + 20 = 65, 65 + 3 = ? |
+| minus 0, or a number from itself | named, no steps | 8 − 0, 8 − 8 |
+| minus, both under ten, no crossing | count back | 8 − 3 |
+| minus, no crossing, tens present | ones only, the tens stay | 48 − 3 → 8 − 3 = ? |
+| minus under ten from a whole ten | take it out of the last ten | 40 − 7 → 10 − 7 = 3, 30 + 3 = ? |
+| minus under ten from exactly 10 | count up | 10 − 7 → 7 + ? = 10 |
+| minus under ten crossing a ten | step down to the ten first | 45 − 7 → 45 − 5 = 40, 40 − 2 = ? |
+| minus ten or more, ones fit | take the tens away first | 95 − 12 → 95 − 10 = 85, 85 − 2 = ? |
+| minus a whole ten | split the first number | 45 − 20 → 40 − 20 = 20, 20 + 5 = ? |
+| minus, both whole tens | tens only, then a zero | 40 − 20 → 4 − 2 = ? |
+| minus ten or more, ones too small | count up from the smaller number over the next ten, then the next hundred | 45 − 17 → 17 + 3 = 20, 20 + 25 = 45, Zusammen: 3 + 25 = ? |
+
+- Custom ranges up to 1000 use the same strategies. The counting-up ladder adds the hundred stone when it helps, for example 345 − 178 → 178 + 2 = 180, 180 + 20 = 200, 200 + 145 = 345.
 
 ## Accessibility
 
@@ -47,6 +87,7 @@ XP:
 
 - Solving a task earns XP scaled by range: base 2 XP times a multiplier of 1 (max <= 10), 2 (<= 20), 3 (<= 50), or 4 (above).
 - Retries cost nothing: a task solved after wrong attempts earns full XP. Struggling is practicing, not failing.
+- Hints cost nothing either: a task solved with the Rechenweg open earns full XP, counts as solved, and feeds every medal counter. Asking how something works is practicing too.
 - Revealed solution: 1 XP flat for the effort. XP never decreases.
 
 Levels (cumulative XP): Zahlenstart 0, Zahlenspringer 20, Rechenfuchs 60, Rechenprofi 150, Zahlenmeister 300, Rechenheld 600. Past the top, XP keeps counting. The setup screen shows a stats strip: level name, XP, progress bar to the next level (progress tokens), and the medal count linking to the gallery.
@@ -69,6 +110,7 @@ Difficulty proposal:
 - Ladder: 0-10 to 0-20 to 0-50 to 0-100. Other presets and custom ranges never trigger proposals.
 - Mastery trigger per GAMIFICATION.md adaptive difficulty: a clean run here is one task solved without a wrong answer. Because a task takes seconds, the threshold is 10 consecutive clean tasks, not the 2 that longer exercises use.
 - On the 10th, the success state shows a proposal instead of Weiter: "Das klappt richtig gut. Möchtest du bis N rechnen?" with "Ja, bis N" (updates the saved setting and continues immediately; the settings screen follows the change) and "Später" (continues unchanged).
+- A task solved with the Rechenweg open is not a clean run: the counter neither advances nor resets. The proposal should follow numbers a learner already does alone.
 - Declining resets the counter silently and re-arms after 10 more. The counter also resets on any wrong answer, on a revealed solution, and when the quiz starts.
 - The range always stays freely selectable in the settings.
 
@@ -76,6 +118,8 @@ Difficulty proposal:
 
 - `add-subtract.settings`: { op, min, max, custom }
 - `add-subtract.stats`: { xp, solved, streak, firstTryStreak, digitsTyped, retriedSolved, minusSolved, max100Solved, rangesSolved }
+- "Alles zurücksetzen" writes an empty stats object and leaves the settings key untouched.
+- Whether a hint was open is per task only. It is never stored.
 
 ## Out of scope
 

--- a/add-subtract/README.md
+++ b/add-subtract/README.md
@@ -8,7 +8,10 @@ Plus und Minus üben. Ruhig, ohne Zeitdruck, ohne Konto. Der Fortschritt bleibt 
 
 1. Rechenart und Zahlenbereich wählen, dann "Los geht's".
 2. Antwort über den Ziffernblock oder die Tastatur eintippen. Bei der letzten Ziffer siehst du sofort, ob es stimmt.
-3. "Weiter" führt zur nächsten Aufgabe.
+3. "Rechenweg zeigen" öffnet einen Tipp in kleinen Schritten, zum Beispiel 45 − 7 über die 40. Der letzte Schritt bleibt offen, das Ergebnis rechnest du selbst. Der Tipp kostet nichts.
+4. "Weiter" führt zur nächsten Aufgabe.
+
+"Alles zurücksetzen" unten auf der Startseite löscht XP, Medaillen und gelöste Aufgaben. Die Einstellungen bleiben, und gefragt wird vorher.
 
 ## Lokal ausführen
 

--- a/add-subtract/index.html
+++ b/add-subtract/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mathe-Trainer</title>
 <meta name="description" content="Plus und Minus üben. Ruhig, ohne Zeitdruck.">
-<link rel="icon" href="favicon.svg?v=3" type="image/svg+xml">
+<link rel="icon" href="favicon.svg?v=4" type="image/svg+xml">
 <style>
   :root {
     --color-background-app: #0E141D;
@@ -123,6 +123,25 @@
   }
   .form-error { color: var(--color-text-secondary); margin: var(--space-3) 0 0; min-height: 1.5em; }
   .range-note { color: var(--color-text-muted); font-size: 0.875rem; margin: var(--space-3) 0 0; }
+  .app-footer {
+    margin-top: var(--space-8);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--color-border-subtle);
+    text-align: center;
+  }
+  .storage-note { color: var(--color-text-muted); font-size: 0.875rem; margin: 0 0 var(--space-2); }
+  .btn-link {
+    background: none;
+    border: none;
+    min-height: 2.75rem;
+    padding: var(--space-2) var(--space-3);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    text-decoration: underline;
+  }
+  .btn-link:hover { background: none; color: var(--color-text-secondary); }
+  .reset-status { color: var(--color-text-secondary); font-size: 0.875rem; margin: var(--space-2) 0 0; }
+  .reset-status:empty { margin: 0; }
   .toolbar {
     display: flex;
     justify-content: space-between;
@@ -158,7 +177,29 @@
   }
   .slot.ok { background: var(--color-success-soft); border-color: var(--color-accent); }
   .slot.wrong { background: var(--color-danger-soft); }
-  .advisory { text-align: center; color: var(--color-text-muted); font-size: 0.875rem; margin: 0 0 var(--space-5); }
+  .advisory { text-align: center; color: var(--color-text-muted); font-size: 0.875rem; margin: 0 0 var(--space-4); }
+  .hint-row { display: flex; justify-content: center; margin-bottom: var(--space-4); }
+  .hint-row button { min-height: 2.75rem; font-size: 0.875rem; display: inline-flex; align-items: center; gap: var(--space-2); }
+  .hint-row button svg { color: var(--color-accent); }
+  .hint {
+    margin: 0 0 var(--space-5);
+    padding: var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--color-background-surface);
+    border: 1px solid var(--color-border-subtle);
+  }
+  .hint:empty { margin: 0; padding: 0; border: none; }
+  .hint-title { margin: 0; font-weight: 600; }
+  .hint-steps {
+    list-style: none;
+    margin: var(--space-3) 0 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2);
+    font-size: 1.125rem;
+    font-variant-numeric: tabular-nums;
+  }
+  .hint-note { margin: var(--space-3) 0 0; color: var(--color-text-secondary); font-size: 0.875rem; }
   .keypad {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -275,6 +316,11 @@
       </button>
     </div>
     <button type="button" class="primary" id="start">Los geht's</button>
+    <footer class="app-footer">
+      <p class="storage-note">Fortschritt und Einstellungen bleiben auf diesem Gerät.</p>
+      <button type="button" class="btn-link" id="reset-all">Alles zurücksetzen</button>
+      <p class="reset-status" id="reset-status" role="status"></p>
+    </footer>
   </section>
 
   <section id="medal-screen" aria-label="Medaillen" hidden>
@@ -294,6 +340,13 @@
     <p class="problem" id="problem"></p>
     <div class="slots" id="slots" aria-label="Deine Antwort" role="group"></div>
     <p class="advisory">Bei der letzten Ziffer siehst du sofort, ob es stimmt.</p>
+    <div class="hint-row">
+      <button type="button" id="hint-toggle" aria-expanded="false" aria-controls="hint">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.8 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg>
+        <span id="hint-toggle-label">Rechenweg zeigen</span>
+      </button>
+    </div>
+    <div class="hint" id="hint" role="status"></div>
     <div class="keypad" id="keypad" aria-label="Ziffernblock" role="group">
       <button type="button" data-digit="1">1</button>
       <button type="button" data-digit="2">2</button>
@@ -388,17 +441,26 @@
   var proposeYes = document.getElementById("propose-yes");
   var proposeLater = document.getElementById("propose-later");
   var nextBtn = document.getElementById("next");
+  var hintEl = document.getElementById("hint");
+  var hintToggle = document.getElementById("hint-toggle");
+  var hintLabel = document.getElementById("hint-toggle-label");
+  var resetStatus = document.getElementById("reset-status");
+
+  function emptyStats() {
+    return {
+      xp: 0, solved: 0, streak: 0, firstTryStreak: 0,
+      digitsTyped: 0, retriedSolved: 0, minusSolved: 0, max100Solved: 0,
+      rangesSolved: {}
+    };
+  }
 
   var settings = { op: "+", min: 0, max: 10, custom: false };
-  var stats = {
-    xp: 0, solved: 0, streak: 0, firstTryStreak: 0,
-    digitsTyped: 0, retriedSolved: 0, minusSolved: 0, max100Solved: 0,
-    rangesSolved: {}
-  };
+  var stats = emptyStats();
   var a = 0, b = 0, correct = 0, answerStr = "";
   var entry = "";
   var attempts = 0;
   var locked = false;
+  var hintUsed = false;
   var proposedMax = 0;
 
   try {
@@ -505,6 +567,8 @@
     entry = "";
     attempts = 0;
     locked = false;
+    hintUsed = false;
+    closeHint();
     problemEl.textContent = a + " " + (settings.op === "+" ? "+" : "−") + " " + b + " =";
     slotsEl.innerHTML = "";
     for (var i = 0; i < answerStr.length; i++) {
@@ -519,12 +583,190 @@
     nextBtn.hidden = true;
   }
 
-  function hint() {
-    if (settings.op === "+") {
-      var large = Math.max(a, b), small = Math.min(a, b);
-      return "Tipp: Beginne bei " + large + " und zähle " + small + " weiter.";
+  // ── Rechenwege ────────────────────────────────────────────────────
+  // A hint breaks the task into easier steps and leaves the last step
+  // open, so the learner still does the closing move. It never writes
+  // out the solved task.
+  function tensOf(n) { return n - (n % 10); }
+
+  // Stepping stones when counting up from one number to another:
+  // the next ten, then the next hundred, then the goal.
+  function stones(from, to) {
+    var list = [];
+    var cur = from;
+    if (cur % 10 !== 0 && tensOf(cur) + 10 <= to) { cur = tensOf(cur) + 10; list.push(cur); }
+    if (cur % 100 !== 0 && cur - (cur % 100) + 100 <= to) { cur = cur - (cur % 100) + 100; list.push(cur); }
+    if (cur < to) list.push(to);
+    return list;
+  }
+
+  function plusHint(x, y) {
+    var big = Math.max(x, y), small = Math.min(x, y);
+    var ones = big % 10;
+    if (small === 0) {
+      return { title: "Wenn du nichts dazuzählst, bleibt die Zahl gleich.", steps: [] };
     }
-    return "Tipp: Beginne bei " + a + " und zähle " + b + " zurück.";
+    if (small < 10) {
+      var toTen = 10 - ones;
+      if (ones + small === 10) {
+        return {
+          title: "Das ergibt genau eine Zehn.",
+          steps: [],
+          note: big + " und " + small + " füllen die nächste Zehn ganz auf."
+        };
+      }
+      if (ones + small > 10) {
+        return {
+          title: "Fülle zuerst auf die nächste Zehn.",
+          steps: [
+            big + " + " + toTen + " = " + (big + toTen),
+            (big + toTen) + " + " + (small - toTen) + " = ?"
+          ],
+          note: "Zerlege die " + small + " in " + toTen + " und " + (small - toTen) + "."
+        };
+      }
+      if (big < 10) {
+        return {
+          title: "Zähle von der grösseren Zahl weiter.",
+          steps: [],
+          note: "Beginne bei " + big + " und zähle " + small + " weiter."
+        };
+      }
+      return {
+        title: "Rechne nur die Einer.",
+        steps: [ones + " + " + small + " = ?"],
+        note: "Die " + tensOf(big) + " davor bleibt gleich."
+      };
+    }
+    if (small % 10 === 0) {
+      if (ones === 0) {
+        return {
+          title: "Rechne nur die Zehner.",
+          steps: [(big / 10) + " + " + (small / 10) + " = ?"],
+          note: "An das Ergebnis kommt noch eine Null."
+        };
+      }
+      return {
+        title: "Zerlege die " + big + " in " + tensOf(big) + " und " + ones + ".",
+        steps: [
+          tensOf(big) + " + " + small + " = " + (tensOf(big) + small),
+          (tensOf(big) + small) + " + " + ones + " = ?"
+        ]
+      };
+    }
+    return {
+      title: "Zerlege die " + small + " in " + tensOf(small) + " und " + (small % 10) + ".",
+      steps: [
+        big + " + " + tensOf(small) + " = " + (big + tensOf(small)),
+        (big + tensOf(small)) + " + " + (small % 10) + " = ?"
+      ]
+    };
+  }
+
+  function minusHint(x, y) {
+    var aOnes = x % 10, bOnes = y % 10;
+    if (y === 0) {
+      return { title: "Wenn du nichts abziehst, bleibt die Zahl gleich.", steps: [] };
+    }
+    if (x === y) {
+      return { title: "Du ziehst die ganze Zahl ab.", steps: [], note: "Es bleibt nichts übrig." };
+    }
+    if (y < 10) {
+      if (aOnes >= y) {
+        if (x < 10) {
+          return {
+            title: "Zähle in kleinen Schritten zurück.",
+            steps: [],
+            note: "Beginne bei " + x + " und zähle " + y + " zurück."
+          };
+        }
+        return {
+          title: "Rechne nur die Einer.",
+          steps: [aOnes + " − " + y + " = ?"],
+          note: "Die " + tensOf(x) + " davor bleibt gleich."
+        };
+      }
+      if (x === 10) {
+        return {
+          title: "Zähle von " + y + " hinauf bis 10.",
+          steps: [y + " + ? = 10"]
+        };
+      }
+      if (aOnes === 0) {
+        return {
+          title: "Nimm es von der letzten Zehn weg.",
+          steps: ["10 − " + y + " = " + (10 - y), (x - 10) + " + " + (10 - y) + " = ?"],
+          note: "Zerlege die " + x + " in " + (x - 10) + " und 10."
+        };
+      }
+      return {
+        title: "Gehe zuerst auf die Zehn.",
+        steps: [x + " − " + aOnes + " = " + tensOf(x), tensOf(x) + " − " + (y - aOnes) + " = ?"],
+        note: "Zerlege die " + y + " in " + aOnes + " und " + (y - aOnes) + "."
+      };
+    }
+    if (aOnes >= bOnes) {
+      if (bOnes === 0) {
+        if (aOnes === 0) {
+          return {
+            title: "Rechne nur die Zehner.",
+            steps: [(x / 10) + " − " + (y / 10) + " = ?"],
+            note: "An das Ergebnis kommt noch eine Null."
+          };
+        }
+        return {
+          title: "Zerlege die " + x + " in " + tensOf(x) + " und " + aOnes + ".",
+          steps: [tensOf(x) + " − " + y + " = " + (tensOf(x) - y), (tensOf(x) - y) + " + " + aOnes + " = ?"]
+        };
+      }
+      return {
+        title: "Ziehe zuerst die Zehner ab.",
+        steps: [
+          x + " − " + tensOf(y) + " = " + (x - tensOf(y)),
+          (x - tensOf(y)) + " − " + bOnes + " = ?"
+        ],
+        note: "Zerlege die " + y + " in " + tensOf(y) + " und " + bOnes + "."
+      };
+    }
+    // The ones digit is too small to take away: count up from the
+    // smaller number instead of subtracting.
+    var marks = stones(y, x);
+    if (marks.length < 2) {
+      return { title: "Zähle von " + y + " hinauf bis " + x + ".", steps: [y + " + ? = " + x] };
+    }
+    var lines = [], parts = [], cur = y;
+    marks.forEach(function (m) {
+      lines.push(cur + " + " + (m - cur) + " = " + m);
+      parts.push(m - cur);
+      cur = m;
+    });
+    lines.push("Zusammen: " + parts.join(" + ") + " = ?");
+    return { title: "Zähle von " + y + " hinauf bis " + x + ".", steps: lines };
+  }
+
+  function renderHint() {
+    var h = settings.op === "+" ? plusHint(a, b) : minusHint(a, b);
+    var html = '<p class="hint-title">' + h.title + "</p>";
+    if (h.steps.length) {
+      html += '<ol class="hint-steps">' + h.steps.map(function (s) {
+        return "<li>" + s + "</li>";
+      }).join("") + "</ol>";
+    }
+    if (h.note) html += '<p class="hint-note">' + h.note + "</p>";
+    hintEl.innerHTML = html;
+  }
+
+  function openHint() {
+    hintUsed = true;
+    renderHint();
+    hintToggle.setAttribute("aria-expanded", "true");
+    hintLabel.textContent = "Rechenweg ausblenden";
+  }
+
+  function closeHint() {
+    hintEl.innerHTML = "";
+    hintToggle.setAttribute("aria-expanded", "false");
+    hintLabel.textContent = "Rechenweg zeigen";
   }
 
   function showReward(xpGain, medalsBefore, levelBefore) {
@@ -558,7 +800,10 @@
     if (solvedByLearner) {
       stats.solved++;
       stats.streak++;
-      if (attempts === 0) stats.firstTryStreak++; else { stats.retriedSolved++; stats.firstTryStreak = 0; }
+      // A hint costs nothing, but a task solved with help does not count
+      // toward the mastery streak that proposes a harder range.
+      if (attempts === 0 && !hintUsed) stats.firstTryStreak++;
+      else if (attempts > 0) { stats.retriedSolved++; stats.firstTryStreak = 0; }
       if (settings.op === "-") stats.minusSolved++;
       if (settings.max >= 100) stats.max100Solved++;
       var key = rangeKey();
@@ -592,7 +837,8 @@
     if (attempts === 1) {
       feedbackEl.textContent = "Fast. Versuch es noch einmal.";
     } else if (attempts === 2) {
-      feedbackEl.textContent = "Fast. " + hint();
+      openHint();
+      feedbackEl.textContent = "Fast. Der Rechenweg unter der Aufgabe hilft dir weiter.";
     } else {
       locked = true;
       entry = answerStr;
@@ -632,6 +878,7 @@
   function showQuiz() {
     setupEl.hidden = true;
     medalScreen.hidden = true;
+    resetStatus.textContent = "";
     quizEl.hidden = false;
     instructionEl.textContent = "Rechne die Aufgabe und tippe die Antwort ein.";
     stats.firstTryStreak = 0;
@@ -692,8 +939,24 @@
     showQuiz();
   });
 
+  hintToggle.addEventListener("click", function () {
+    if (hintToggle.getAttribute("aria-expanded") === "true") closeHint();
+    else openHint();
+  });
+
+  document.getElementById("reset-all").addEventListener("click", function () {
+    var ok = confirm("Allen Fortschritt löschen? XP, Medaillen und gelöste Aufgaben verschwinden. Die Daten liegen nur auf diesem Gerät.");
+    if (!ok) return;
+    stats = emptyStats();
+    save();
+    renderStats();
+    renderProgress();
+    resetStatus.textContent = "Der Fortschritt wurde gelöscht. Die Einstellungen bleiben.";
+  });
+
   document.getElementById("change-settings").addEventListener("click", showSetup);
   document.getElementById("show-medals").addEventListener("click", function () {
+    resetStatus.textContent = "";
     setupEl.hidden = true;
     medalScreen.hidden = false;
     instructionEl.textContent = "Deine Medaillen. Offene Ziele bleiben sichtbar.";
@@ -730,6 +993,10 @@
     if (e.key >= "0" && e.key <= "9") { pressDigit(e.key); }
     else if (e.key === "Backspace") { backspace(); e.preventDefault(); }
     else if (e.key === "Enter") {
+      // A focused button already handles Enter itself. Without this the
+      // quiz would act twice, for example open the Rechenweg and jump to
+      // the next task in the same keypress.
+      if (e.target && e.target.closest && e.target.closest("button")) return;
       if (!proposalEl.hidden) proposeLater.click();
       else if (!nextBtn.hidden) newProblem();
     }

--- a/add-subtract/tests/e2e.test.mjs
+++ b/add-subtract/tests/e2e.test.mjs
@@ -53,6 +53,29 @@ await new Promise(r => setTimeout(r, 800));
 
 const browser = await chromium.launch({ executablePath: CHROMIUM });
 const page = await browser.newPage({ viewport: { width: 420, height: 900 } });
+
+// Lets a test queue the exact numbers the generator should draw next.
+// With an empty queue the app uses real randomness, so every other check
+// still runs against ordinary problems.
+await page.addInitScript(() => {
+  const real = Math.random;
+  window.__rand = [];
+  Math.random = () => (window.__rand.length ? window.__rand.shift() : real());
+});
+// The generator draws the result first, then one operand, both from
+// [0, max]. These are the two draws that produce a given task.
+const drawsFor = (op, a, b, max) => {
+  const result = op === "+" ? a + b : a - b;
+  return op === "+"
+    ? [(result + 0.5) / (max + 1), (a + 0.5) / (result + 1)]
+    : [(result + 0.5) / (max + 1), (b + 0.5) / (max - result + 1)];
+};
+const forceProblem = (op, a, b, max) =>
+  page.evaluate(d => { window.__rand = d; }, drawsFor(op, a, b, max));
+// Queues several tasks in a row, so a test can tell one advance from two.
+const forceProblems = (list) =>
+  page.evaluate(d => { window.__rand = d; }, list.flatMap(p => drawsFor(...p)));
+
 const consoleErrors = [];
 page.on("console", msg => { if (msg.type() === "error") consoleErrors.push(msg.text()); });
 page.on("pageerror", err => consoleErrors.push(String(err)));
@@ -203,6 +226,143 @@ try {
   check("accepting raises the range to 0-20",
     await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.settings")).max === 20));
   check("quiz continues after accepting", (await page.textContent("#feedback")).trim() === "");
+
+  // ── Rechenweg hints ───────────────────────────────────────────────
+  const hintSteps = () => page.$$eval(".hint-steps li", els => els.map(e => e.textContent));
+
+  await page.click("#change-settings");
+  await page.click('#op-chips button[data-op="-"]');
+  await page.click('#range-chips button[data-min="0"][data-max="100"]');
+  await forceProblem("-", 45, 7, 100);
+  await page.click("#start");
+  check("test can force a specific problem", (await page.textContent("#problem")).trim() === "45 − 7 =");
+  check("hint stays closed until asked", (await page.textContent("#hint")).trim() === "");
+  check("hint toggle starts collapsed", await page.getAttribute("#hint-toggle", "aria-expanded") === "false");
+  await page.click("#hint-toggle");
+  check("45 − 7 steps down to the ten first",
+    (await hintSteps()).join(" | ") === "45 − 5 = 40 | 40 − 2 = ?");
+  check("hint names the strategy", (await page.textContent(".hint-title")) === "Gehe zuerst auf die Zehn.");
+  check("hint leaves the answer to the learner", !(await page.textContent("#hint")).includes("38"));
+  check("hint region is a status region (WCAG 4.1.3)", await page.getAttribute("#hint", "role") === "status");
+  check("toggle reports the expanded state", await page.getAttribute("#hint-toggle", "aria-expanded") === "true");
+  await page.screenshot({ path: join(SHOTS_DIR, "06-hint-minus-small.png") });
+  await page.click("#hint-toggle");
+  check("hint can be collapsed again",
+    (await page.textContent("#hint")).trim() === ""
+    && await page.getAttribute("#hint-toggle", "aria-expanded") === "false");
+
+  await typeAnswer("38");
+  await forceProblem("-", 45, 17, 100);
+  await page.click("#next");
+  check("second forced problem is 45 − 17", (await page.textContent("#problem")).trim() === "45 − 17 =");
+  await page.click("#hint-toggle");
+  check("45 − 17 counts up from the subtrahend",
+    (await hintSteps()).join(" | ") === "17 + 3 = 20 | 20 + 25 = 45 | Zusammen: 3 + 25 = ?");
+  check("counting-up hint leaves the answer open", !(await page.textContent("#hint")).includes("28"));
+  await page.screenshot({ path: join(SHOTS_DIR, "07-hint-minus-crossing.png") });
+
+  // Enter on a focused button does that button's job and nothing else,
+  // even while Weiter is on screen and listening for Enter.
+  await page.click("#hint-toggle");
+  await typeAnswer("28");
+  await forceProblems([["-", 45, 7, 100], ["-", 20, 5, 100]]);
+  await page.focus("#hint-toggle");
+  await page.keyboard.press("Enter");
+  check("Enter on the hint toggle does not skip the solved task",
+    (await page.textContent("#problem")).trim() === "45 − 17 =",
+    await page.textContent("#problem"));
+  check("Enter on the hint toggle opens the hint",
+    await page.getAttribute("#hint-toggle", "aria-expanded") === "true");
+
+  // Two tasks are queued, so a double advance would show the second one.
+  await page.focus("#next");
+  await page.keyboard.press("Enter");
+  check("Enter on Weiter advances exactly one task",
+    (await page.textContent("#problem")).trim() === "45 − 7 =",
+    await page.textContent("#problem"));
+  check("Weiter via Enter clears the feedback", (await page.textContent("#feedback")).trim() === "");
+  await page.evaluate(() => { window.__rand = []; });
+
+  await page.click("#change-settings");
+  await page.click('#op-chips button[data-op="+"]');
+  await page.click('#range-chips button[data-min="0"][data-max="20"]');
+  await forceProblem("+", 8, 7, 20);
+  await page.click("#start");
+  check("plus problem forced to 8 + 7", (await page.textContent("#problem")).trim() === "8 + 7 =");
+  await page.click("#hint-toggle");
+  check("8 + 7 fills up to the next ten",
+    (await hintSteps()).join(" | ") === "8 + 2 = 10 | 10 + 5 = ?");
+  await page.click("#hint-toggle");
+
+  // Second miss opens the hint by itself.
+  for (let i = 0; i < 2; i++) {
+    await typeAnswer("16");
+    if (i === 0) for (const _ of "16") await page.click("#backspace");
+  }
+  check("second miss opens the hint automatically",
+    await page.getAttribute("#hint-toggle", "aria-expanded") === "true"
+    && (await page.textContent(".hint-title")).length > 0);
+  check("feedback points at the hint instead of repeating it",
+    (await page.textContent("#feedback")).includes("Rechenweg"));
+  await page.screenshot({ path: join(SHOTS_DIR, "08-hint-after-second-miss.png") });
+  for (const _ of "16") await page.click("#backspace");
+  await typeAnswer("15");
+  check("solving after the hint still counts and pays full XP",
+    (await page.textContent("#reward")).includes("XP"));
+
+  // A hint costs nothing but does not feed the mastery streak.
+  await page.click("#change-settings");
+  await forceProblem("+", 8, 7, 20);
+  await page.click("#start");
+  await page.click("#hint-toggle");
+  await typeAnswer("15");
+  check("a hinted task does not raise the clean-run streak",
+    await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.stats")).firstTryStreak === 0));
+  const solvedBefore = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem("add-subtract.stats")).solved);
+  await page.click("#next");
+  ({ answer } = await readProblem());
+  await typeAnswer(String(answer));
+  check("an unhinted solve raises the clean-run streak",
+    await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.stats")).firstTryStreak === 1));
+  check("hinted solves still count as solved",
+    await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.stats")).solved) === solvedBefore + 1);
+
+  // ── Alles zurücksetzen ────────────────────────────────────────────
+  await page.click("#change-settings");
+  check("reset lives in the home footer, not in the quiz",
+    await page.isVisible(".app-footer #reset-all") && !(await page.isVisible("#quiz")));
+
+  let dialogText = "";
+  page.once("dialog", d => { dialogText = d.message(); d.dismiss(); });
+  await page.click("#reset-all");
+  check("reset asks before deleting", dialogText.length > 0);
+  check("confirmation says the data lives on this device", dialogText.includes("Gerät"), dialogText);
+  check("cancelling keeps the progress",
+    await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.stats")).solved > 0));
+
+  page.once("dialog", d => d.accept());
+  await page.click("#reset-all");
+  const after = await page.evaluate(() => JSON.parse(localStorage.getItem("add-subtract.stats")));
+  check("reset clears XP, solves and streak", after.xp === 0 && after.solved === 0 && after.streak === 0);
+  check("reset clears the medal counters",
+    after.digitsTyped === 0 && after.minusSolved === 0 && Object.keys(after.rangesSolved).length === 0);
+  check("reset keeps the settings",
+    await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem("add-subtract.settings"));
+      return s.op === "+" && s.max === 20;
+    }));
+  check("progress box shows the first level again",
+    (await page.textContent("#level-name")) === "Zahlenstart");
+  check("medal count is back to zero", (await page.textContent("#medal-count")).includes("0 von 8"));
+  check("reset is announced in a status region",
+    await page.getAttribute("#reset-status", "role") === "status"
+    && (await page.textContent("#reset-status")).length > 0);
+  await page.screenshot({ path: join(SHOTS_DIR, "09-reset.png"), fullPage: true });
+  await page.click("#show-medals");
+  check("medals are locked again after the reset",
+    await page.evaluate(() => document.querySelectorAll(".medal.locked").length === 8));
+  await page.click("#medals-back");
 
   check("no console errors", consoleErrors.length === 0, consoleErrors.join(" | "));
 } finally {


### PR DESCRIPTION
Two additions to `add-subtract`.

## Alles zurücksetzen

The home footer now carries the storage note and a link-styled "Alles zurücksetzen", following the Nummernfuchs pattern that PRODUCT.md asks for: destructive controls stay in the home footer, never in settings.

- Confirms first and names both what goes and where the data lives.
- Clears `add-subtract.stats`, so XP, level, streak, solve counters and every medal go back to zero together.
- Keeps `add-subtract.settings`. A child practising minus up to 100 should not land back on plus up to 10.
- The stats strip and the medal count re-render at once, and a `role="status"` line reports the deletion.

## Rechenweg

The quiz gets a "Rechenweg zeigen" toggle under the answer slots (Lucide `lightbulb`, `aria-expanded`, `aria-controls`). It breaks the task into steps small enough to do in the head and leaves exactly the last one open with "?", so the answer stays the learner's move. It never writes out the solved task.

```
45 − 7 =        Gehe zuerst auf die Zehn.        45 − 5 = 40
                                                 40 − 2 = ?

45 − 17 =       Zähle von 17 hinauf bis 45.      17 + 3 = 20
                                                 20 + 25 = 45
                                                 Zusammen: 3 + 25 = ?
```

The strategy follows from the numbers of the task: filling up to the next ten, splitting a number into tens and ones, taking a number out of the last ten, or counting up when the ones digit is too small to take away. It covers both operations from single digits to custom ranges up to 1000, where the counting-up ladder adds a hundred stone. The full table is in `add-subtract/PRD.md`.

The second wrong attempt opens the hint by itself, replacing the one-line counting tip that used to go into the feedback.

A hint is free: full XP, the solve counts, medal counters unaffected. It only keeps that task out of the clean-run streak behind the difficulty proposal, which should follow numbers a learner already does alone.

## Also fixed

With "Weiter" on screen, Enter on any other focused button ran that button and advanced the task in the same keypress, so pressing Enter on the hint toggle skipped the task. Enter on a focused button now does that button's job only.

## Verification

- `add-subtract/tests/e2e.test.mjs` extended and passing, 74 checks, no console errors. The suite can now force a specific task through the generator, so both examples above are asserted step by step, as are the reset flow (cancel, confirm, settings survive, medals locked again) and the Enter fix, which was confirmed to fail without it.
- The hint engine was checked against 1,016,550 tasks across every preset and the 0-1000 custom range: every step arithmetically true, exactly one open step, and the solved task never printed.
- Screenshots taken at 360, 420 and 1280 wide, including the hint after a second miss and the footer after a reset.
- Cache buster bumped to `?v=4`.
- PRD, README and the app CLAUDE.md updated in the same change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpYnVTCzBBTURM3GiggCF1)_