### PR TITLE
Pick the Rechenweg by four questions in order

### DIFF
--- a/add-subtract/CLAUDE.md
+++ b/add-subtract/CLAUDE.md
@@ -4,7 +4,9 @@
 - Single-file app: all CSS and JS live inline in index.html. The only local asset is favicon.svg, which carries the `?v=N` cache buster.
 - The answer input implements the known-length input pattern from PRODUCT.md. Never add a confirm button to it and never add auto-advance timers.
 - The progression layer (XP, levels, medals, difficulty proposal) follows GAMIFICATION.md. Medal checks are pure functions of the stats object; never add event flags. Rewards render only in the post-task block, never during input.
-- Hints (`plusHint` and `minusHint`) are pure functions of the two operands. Two rules hold for every branch: the steps must be arithmetically true, and exactly the last step stays open with "?", so the hint never writes out the solved task. When you touch a branch, check the whole table in PRD.md again, including custom ranges up to 1000.
+- Hints (`plusHint` and `minusHint`) are pure functions of the two operands. They answer four questions in order, listed in PRD.md: close to the first number, close to a whole ten, do the ones cross a ten, otherwise tens before ones. Keep that order intact; changing it changes what a child is taught.
+- Every hint returns a `rule` id naming the branch that produced it. It is not rendered, it keeps the tests and the PRD table honest.
+- Four rules hold for every branch: the steps are arithmetically true, exactly the last step stays open with "?", no step starts from a pointless zero, and at most three steps. The hint never writes out the solved task. When you touch a branch, re-check the whole table in PRD.md, including custom ranges up to 1000.
 - A hint is free. It never costs XP and never blocks a medal. It only keeps the task out of the clean-run streak behind the difficulty proposal.
 - "Alles zurücksetzen" belongs in the home footer with its confirm, per PRODUCT.md. It clears `add-subtract.stats` and keeps `add-subtract.settings`.
 - PRD.md in this folder is the single source of truth for behavior. Update it in the same change as any behavior change, and keep the e2e suite in tests/ passing.

--- a/add-subtract/PRD.md
+++ b/add-subtract/PRD.md
@@ -48,30 +48,46 @@ A hint shows how to get to the answer, not the answer itself.
 - The hint block sits between the toggle and the keypad and is a `role="status"` region, so opening it is announced. It holds a title naming the strategy, the steps as an unnumbered ordered list, and an optional short note.
 - Every hint breaks the task into steps small enough to do in the head and leaves exactly the last one open with "?", so the learner still makes the closing move. A hint never writes out the solved task.
 - The hint stays until "Weiter" and stays available after the task is solved.
-- The strategy follows from the numbers of the current task:
+- The learner can open it at any time. Nothing has to go wrong first.
 
-| Task shape | Strategy | Example |
+### Choosing the way, minus
+
+Four questions in order, the way a child would pick a way through. The first one that fits wins. Each hint carries the id of the rule that produced it, so the tests and this table stay in step.
+
+| # | Question | Rule id | Way | Example |
+| --- | --- | --- | --- | --- |
+| 1 | Is the number to take away close to the first one, at most 10 below it? | close | Count up from it, over the next ten and the next hundred. | 25 − 17 → 17 + 3 = 20, 20 + 5 = 25, Zusammen: 3 + 5 = ? |
+| 2 | Is it 1 or 2 below a whole ten? | round | Round it up, take that away, give the difference back. | 82 − 29 → 82 − 30 = 52, 52 + 1 = ? |
+| 3 | Do the ones cross a ten? | bridge | Take the tens away first, then step onto the ten, then the rest. | 42 − 7 → 42 − 2 = 40, 40 − 5 = ?<br>45 − 17 → 45 − 10 = 35, 35 − 5 = 30, 30 − 2 = ? |
+| 4 | Otherwise | steps | Tens first, then the ones. | 82 − 31 → 82 − 30 = 52, 52 − 1 = ? |
+
+Question 1 asks about closeness, not about size: 45 − 17 is 28 apart, so it bridges rather than counting up.
+
+Before the four questions, three shapes answer themselves:
+
+| Task shape | Rule id | Way |
 | --- | --- | --- |
-| plus, one part 0 | nothing changes | 7 + 0 |
-| plus, small part crosses a ten | fill up to the ten | 8 + 7 → 8 + 2 = 10, 10 + 5 = ? |
-| plus, small part lands on the ten | named, no steps | 5 + 5 |
-| plus, both parts under ten, no crossing | count on from the larger part | 3 + 4 |
-| plus, no crossing, tens present | ones only, the tens stay | 45 + 3 → 5 + 3 = ? |
-| plus, both parts whole tens | tens only, then a zero | 40 + 20 → 4 + 2 = ? |
-| plus, second part a whole ten | split the other number | 23 + 40 → 40 + 20 = 60, 60 + 3 = ? |
-| plus, two parts of ten or more | split the smaller into tens and ones | 23 + 45 → 45 + 20 = 65, 65 + 3 = ? |
-| minus 0, or a number from itself | named, no steps | 8 − 0, 8 − 8 |
-| minus, both under ten, no crossing | count back | 8 − 3 |
-| minus, no crossing, tens present | ones only, the tens stay | 48 − 3 → 8 − 3 = ? |
-| minus under ten from a whole ten | take it out of the last ten | 40 − 7 → 10 − 7 = 3, 30 + 3 = ? |
-| minus under ten from exactly 10 | count up | 10 − 7 → 7 + ? = 10 |
-| minus under ten crossing a ten | step down to the ten first | 45 − 7 → 45 − 5 = 40, 40 − 2 = ? |
-| minus ten or more, ones fit | take the tens away first | 95 − 12 → 95 − 10 = 85, 85 − 2 = ? |
-| minus a whole ten | split the first number | 45 − 20 → 40 − 20 = 20, 20 + 5 = ? |
-| minus, both whole tens | tens only, then a zero | 40 − 20 → 4 − 2 = ? |
-| minus ten or more, ones too small | count up from the smaller number over the next ten, then the next hundred | 45 − 17 → 17 + 3 = 20, 20 + 25 = 45, Zusammen: 3 + 25 = ? |
+| minus 0, or a number from itself | trivial | Named in one line, no steps. |
+| both numbers under ten | simple | Count back from the first one. |
+| standing exactly on 10 | close | The number pair to ten: 10 − 7 → 7 + ? = 10 |
 
-- Custom ranges up to 1000 use the same strategies. The counting-up ladder adds the hundred stone when it helps, for example 345 − 178 → 178 + 2 = 180, 180 + 20 = 200, 200 + 145 = 345.
+Inside question 3 and 4 the wording follows the numbers: the ones alone where the tens do not move (48 − 3 → 8 − 3 = ?), the tens alone where both are whole tens (40 − 20 → 4 − 2 = ?), splitting the first number where the second is a whole ten (45 − 20 → 40 − 20 = 20, 20 + 5 = ?), and taking the rest out of the last ten where the first number is a whole ten (40 − 7 → 10 − 7 = 3, 30 + 3 = ?).
+
+### Choosing the way, plus
+
+The same order without question 1, which has no meaning for addition.
+
+| # | Question | Rule id | Way | Example |
+| --- | --- | --- | --- | --- |
+| 2 | Is the smaller part 1 or 2 below a whole ten, and the larger part at least 10? | round | Round it up, add that, take the difference off again. | 45 + 19 → 45 + 20 = 65, 65 − 1 = ? |
+| 3 | Do the ones cross a ten? | fill | Fill up to the ten first. | 8 + 7 → 8 + 2 = 10, 10 + 5 = ? |
+| 4 | Otherwise | steps | Tens first, then the ones. | 23 + 45 → 45 + 20 = 65, 65 + 3 = ? |
+
+Plus 0 is named in one line (trivial), two single digits that do not cross are counted on from the larger part (simple), and a part that lands exactly on the ten is named rather than stepped (5 + 5, fill).
+
+### Range
+
+Custom ranges up to 1000 use the same questions. Counting up adds the hundred stone when it helps, for example 345 − 338 → 338 + 2 = 340, 340 + 5 = 345. No hint is longer than three steps.
 
 ## Accessibility
 

--- a/add-subtract/README.md
+++ b/add-subtract/README.md
@@ -8,7 +8,7 @@ Plus und Minus üben. Ruhig, ohne Zeitdruck, ohne Konto. Der Fortschritt bleibt 
 
 1. Rechenart und Zahlenbereich wählen, dann "Los geht's".
 2. Antwort über den Ziffernblock oder die Tastatur eintippen. Bei der letzten Ziffer siehst du sofort, ob es stimmt.
-3. "Rechenweg zeigen" öffnet einen Tipp in kleinen Schritten, zum Beispiel 45 − 7 über die 40. Der letzte Schritt bleibt offen, das Ergebnis rechnest du selbst. Der Tipp kostet nichts.
+3. "Rechenweg zeigen" öffnet jederzeit einen Tipp in kleinen Schritten: 42 − 7 geht über die 40, 82 − 29 rundet auf 30 und gibt 1 zurück, 25 − 17 zählt hinauf. Der letzte Schritt bleibt offen, das Ergebnis rechnest du selbst. Der Tipp kostet nichts.
 4. "Weiter" führt zur nächsten Aufgabe.
 
 "Alles zurücksetzen" unten auf der Startseite löscht XP, Medaillen und gelöste Aufgaben. Die Einstellungen bleiben, und gefragt wird vorher.

--- a/add-subtract/index.html
+++ b/add-subtract/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mathe-Trainer</title>
 <meta name="description" content="Plus und Minus üben. Ruhig, ohne Zeitdruck.">
-<link rel="icon" href="favicon.svg?v=4" type="image/svg+xml">
+<link rel="icon" href="favicon.svg?v=5" type="image/svg+xml">
 <style>
   :root {
     --color-background-app: #0E141D;
@@ -600,23 +600,63 @@
     return list;
   }
 
+  // How far a number sits below the next whole ten. 1 or 2 means it is
+  // close enough to round up and give the difference back afterwards.
+  function toNextTen(n) { return (10 - (n % 10)) % 10; }
+
+  // Counting up from the smaller number to the larger one.
+  function countUp(from, to) {
+    var marks = stones(from, to);
+    if (marks.length < 2) {
+      return {
+        rule: "close",
+        title: "Zähle von " + from + " hinauf bis " + to + ".",
+        steps: [from + " + ? = " + to]
+      };
+    }
+    var lines = [], parts = [], cur = from;
+    marks.forEach(function (m) {
+      lines.push(cur + " + " + (m - cur) + " = " + m);
+      parts.push(m - cur);
+      cur = m;
+    });
+    lines.push("Zusammen: " + parts.join(" + ") + " = ?");
+    return { rule: "close", title: "Zähle von " + from + " hinauf bis " + to + ".", steps: lines };
+  }
+
   function plusHint(x, y) {
     var big = Math.max(x, y), small = Math.min(x, y);
     var ones = big % 10;
     if (small === 0) {
-      return { title: "Wenn du nichts dazuzählst, bleibt die Zahl gleich.", steps: [] };
+      return { rule: "trivial", title: "Wenn du nichts dazuzählst, bleibt die Zahl gleich.", steps: [] };
+    }
+    // Close to a whole ten: round up, then take the extra back off.
+    var up = toNextTen(small);
+    if (up > 0 && up <= 2 && big >= 10) {
+      return {
+        rule: "round",
+        title: "Runde die " + small + " auf " + (small + up) + ".",
+        steps: [
+          big + " + " + (small + up) + " = " + (big + small + up),
+          (big + small + up) + " − " + up + " = ?"
+        ],
+        note: "Du hast " + up + " zu viel dazugezählt, darum kommt " + up + " wieder weg."
+      };
     }
     if (small < 10) {
       var toTen = 10 - ones;
       if (ones + small === 10) {
         return {
+          rule: "fill",
           title: "Das ergibt genau eine Zehn.",
           steps: [],
           note: big + " und " + small + " füllen die nächste Zehn ganz auf."
         };
       }
+      // The ones cross a ten: fill up to it first.
       if (ones + small > 10) {
         return {
+          rule: "fill",
           title: "Fülle zuerst auf die nächste Zehn.",
           steps: [
             big + " + " + toTen + " = " + (big + toTen),
@@ -627,12 +667,22 @@
       }
       if (big < 10) {
         return {
+          rule: "simple",
           title: "Zähle von der grösseren Zahl weiter.",
           steps: [],
           note: "Beginne bei " + big + " und zähle " + small + " weiter."
         };
       }
+      if (ones === 0) {
+        return {
+          rule: "steps",
+          title: "Die Einer kommen einfach dazu.",
+          steps: [],
+          note: "Die " + big + " bleibt gleich, die " + small + " stellst du dahinter."
+        };
+      }
       return {
+        rule: "steps",
         title: "Rechne nur die Einer.",
         steps: [ones + " + " + small + " = ?"],
         note: "Die " + tensOf(big) + " davor bleibt gleich."
@@ -641,12 +691,14 @@
     if (small % 10 === 0) {
       if (ones === 0) {
         return {
+          rule: "steps",
           title: "Rechne nur die Zehner.",
           steps: [(big / 10) + " + " + (small / 10) + " = ?"],
           note: "An das Ergebnis kommt noch eine Null."
         };
       }
       return {
+        rule: "steps",
         title: "Zerlege die " + big + " in " + tensOf(big) + " und " + ones + ".",
         steps: [
           tensOf(big) + " + " + small + " = " + (tensOf(big) + small),
@@ -654,7 +706,9 @@
         ]
       };
     }
+    // Tens first, then the ones.
     return {
+      rule: "steps",
       title: "Zerlege die " + small + " in " + tensOf(small) + " und " + (small % 10) + ".",
       steps: [
         big + " + " + tensOf(small) + " = " + (big + tensOf(small)),
@@ -663,85 +717,108 @@
     };
   }
 
+  // Four questions in order, the way a child would pick a way through:
+  // 1. Is the number to take away close to the first one? Count up.
+  // 2. Is it close to a whole ten? Round it and give the rest back.
+  // 3. Do the ones cross a ten? Go over the ten in steps.
+  // 4. Otherwise take the tens away first, then the ones.
   function minusHint(x, y) {
     var aOnes = x % 10, bOnes = y % 10;
+    var bTens = tensOf(y);
     if (y === 0) {
-      return { title: "Wenn du nichts abziehst, bleibt die Zahl gleich.", steps: [] };
+      return { rule: "trivial", title: "Wenn du nichts abziehst, bleibt die Zahl gleich.", steps: [] };
     }
     if (x === y) {
-      return { title: "Du ziehst die ganze Zahl ab.", steps: [], note: "Es bleibt nichts übrig." };
+      return { rule: "trivial", title: "Du ziehst die ganze Zahl ab.", steps: [], note: "Es bleibt nichts übrig." };
     }
-    if (y < 10) {
-      if (aOnes >= y) {
-        if (x < 10) {
-          return {
-            title: "Zähle in kleinen Schritten zurück.",
-            steps: [],
-            note: "Beginne bei " + x + " und zähle " + y + " zurück."
-          };
-        }
-        return {
-          title: "Rechne nur die Einer.",
-          steps: [aOnes + " − " + y + " = ?"],
-          note: "Die " + tensOf(x) + " davor bleibt gleich."
-        };
-      }
-      if (x === 10) {
-        return {
-          title: "Zähle von " + y + " hinauf bis 10.",
-          steps: [y + " + ? = 10"]
-        };
+    if (x < 10) {
+      return {
+        rule: "simple",
+        title: "Zähle in kleinen Schritten zurück.",
+        steps: [],
+        note: "Beginne bei " + x + " und zähle " + y + " zurück."
+      };
+    }
+    // Standing exactly on the ten: this is the number pair to 10.
+    if (x === 10) return countUp(y, 10);
+    // 1. Close to the first number: counting up is shorter than taking away.
+    if (y >= 10 && x - y <= 10) return countUp(y, x);
+    // 2. Close to a whole ten: round up, then give the difference back.
+    var up = toNextTen(y);
+    if (up > 0 && up <= 2) {
+      return {
+        rule: "round",
+        title: "Runde die " + y + " auf " + (y + up) + ".",
+        steps: [
+          x + " − " + (y + up) + " = " + (x - y - up),
+          (x - y - up) + " + " + up + " = ?"
+        ],
+        note: "Du hast " + up + " zu viel abgezogen, darum kommt " + up + " wieder dazu."
+      };
+    }
+    // 3. The ones cross a ten: take the tens away, then step over the ten.
+    if (aOnes < bOnes) {
+      var lines = [];
+      var cur = x;
+      if (bTens > 0) {
+        cur = x - bTens;
+        lines.push(x + " − " + bTens + " = " + cur);
       }
       if (aOnes === 0) {
+        // Standing on a whole ten: take the rest out of the last ten.
+        lines.push("10 − " + bOnes + " = " + (10 - bOnes));
+        lines.push((cur - 10) + " + " + (10 - bOnes) + " = ?");
         return {
-          title: "Nimm es von der letzten Zehn weg.",
-          steps: ["10 − " + y + " = " + (10 - y), (x - 10) + " + " + (10 - y) + " = ?"],
-          note: "Zerlege die " + x + " in " + (x - 10) + " und 10."
+          rule: "bridge",
+          title: bTens > 0 ? "Ziehe zuerst die Zehner ab." : "Nimm es von der letzten Zehn weg.",
+          steps: lines,
+          note: "Zerlege die " + cur + " in " + (cur - 10) + " und 10."
         };
       }
+      lines.push(cur + " − " + aOnes + " = " + tensOf(cur));
+      lines.push(tensOf(cur) + " − " + (bOnes - aOnes) + " = ?");
       return {
+        rule: "bridge",
         title: "Gehe zuerst auf die Zehn.",
-        steps: [x + " − " + aOnes + " = " + tensOf(x), tensOf(x) + " − " + (y - aOnes) + " = ?"],
-        note: "Zerlege die " + y + " in " + aOnes + " und " + (y - aOnes) + "."
+        steps: lines,
+        note: bTens > 0
+          ? "Zerlege die " + y + " in " + bTens + ", " + aOnes + " und " + (bOnes - aOnes) + "."
+          : "Zerlege die " + y + " in " + aOnes + " und " + (bOnes - aOnes) + "."
       };
     }
-    if (aOnes >= bOnes) {
-      if (bOnes === 0) {
-        if (aOnes === 0) {
-          return {
-            title: "Rechne nur die Zehner.",
-            steps: [(x / 10) + " − " + (y / 10) + " = ?"],
-            note: "An das Ergebnis kommt noch eine Null."
-          };
-        }
+    // 4. Nothing crosses: tens first, then the ones.
+    if (y < 10) {
+      return {
+        rule: "steps",
+        title: "Rechne nur die Einer.",
+        steps: [aOnes + " − " + y + " = ?"],
+        note: "Die " + tensOf(x) + " davor bleibt gleich."
+      };
+    }
+    if (bOnes === 0) {
+      if (aOnes === 0) {
         return {
-          title: "Zerlege die " + x + " in " + tensOf(x) + " und " + aOnes + ".",
-          steps: [tensOf(x) + " − " + y + " = " + (tensOf(x) - y), (tensOf(x) - y) + " + " + aOnes + " = ?"]
+          rule: "steps",
+          title: "Rechne nur die Zehner.",
+          steps: [(x / 10) + " − " + (y / 10) + " = ?"],
+          note: "An das Ergebnis kommt noch eine Null."
         };
       }
       return {
-        title: "Ziehe zuerst die Zehner ab.",
-        steps: [
-          x + " − " + tensOf(y) + " = " + (x - tensOf(y)),
-          (x - tensOf(y)) + " − " + bOnes + " = ?"
-        ],
-        note: "Zerlege die " + y + " in " + tensOf(y) + " und " + bOnes + "."
+        rule: "steps",
+        title: "Zerlege die " + x + " in " + tensOf(x) + " und " + aOnes + ".",
+        steps: [tensOf(x) + " − " + y + " = " + (tensOf(x) - y), (tensOf(x) - y) + " + " + aOnes + " = ?"]
       };
     }
-    // The ones digit is too small to take away: count up from the
-    // smaller number instead of subtracting.
-    var marks = stones(y, x);
-    if (marks.length < 2) {
-      return { title: "Zähle von " + y + " hinauf bis " + x + ".", steps: [y + " + ? = " + x] };
-    }
-    var lines = [], parts = [], cur = y;
-    marks.forEach(function (m) {
-      lines.push(cur + " + " + (m - cur) + " = " + m);
-      parts.push(m - cur);
-      cur = m;
-    });
-    lines.push("Zusammen: " + parts.join(" + ") + " = ?");
-    return { title: "Zähle von " + y + " hinauf bis " + x + ".", steps: lines };
+    return {
+      rule: "steps",
+      title: "Ziehe zuerst die Zehner ab.",
+      steps: [
+        x + " − " + bTens + " = " + (x - bTens),
+        (x - bTens) + " − " + bOnes + " = ?"
+      ],
+      note: "Zerlege die " + y + " in " + bTens + " und " + bOnes + "."
+    };
   }
 
   function renderHint() {

--- a/add-subtract/tests/e2e.test.mjs
+++ b/add-subtract/tests/e2e.test.mjs
@@ -230,40 +230,72 @@ try {
   // ── Rechenweg hints ───────────────────────────────────────────────
   const hintSteps = () => page.$$eval(".hint-steps li", els => els.map(e => e.textContent));
 
-  await page.click("#change-settings");
-  await page.click('#op-chips button[data-op="-"]');
-  await page.click('#range-chips button[data-min="0"][data-max="100"]');
-  await forceProblem("-", 45, 7, 100);
-  await page.click("#start");
-  check("test can force a specific problem", (await page.textContent("#problem")).trim() === "45 − 7 =");
-  check("hint stays closed until asked", (await page.textContent("#hint")).trim() === "");
-  check("hint toggle starts collapsed", await page.getAttribute("#hint-toggle", "aria-expanded") === "false");
-  await page.click("#hint-toggle");
-  check("45 − 7 steps down to the ten first",
-    (await hintSteps()).join(" | ") === "45 − 5 = 40 | 40 − 2 = ?");
-  check("hint names the strategy", (await page.textContent(".hint-title")) === "Gehe zuerst auf die Zehn.");
-  check("hint leaves the answer to the learner", !(await page.textContent("#hint")).includes("38"));
+  // The strategy is picked by four questions in order: is the second
+  // number close to the first, is it close to a whole ten, do the ones
+  // cross a ten, otherwise tens first and then ones.
+  const CASES = [
+    { op: "-", a: 82, b: 31, rule: "tens first, then ones",
+      title: "Ziehe zuerst die Zehner ab.", steps: ["82 − 30 = 52", "52 − 1 = ?"], shot: null },
+    { op: "-", a: 25, b: 17, rule: "close to the first number, count up",
+      title: "Zähle von 17 hinauf bis 25.", steps: ["17 + 3 = 20", "20 + 5 = 25", "Zusammen: 3 + 5 = ?"],
+      shot: "07-hint-count-up.png" },
+    { op: "-", a: 42, b: 7, rule: "ones cross a ten, bridge",
+      title: "Gehe zuerst auf die Zehn.", steps: ["42 − 2 = 40", "40 − 5 = ?"], shot: null },
+    { op: "-", a: 82, b: 29, rule: "close to a whole ten, round and give back",
+      title: "Runde die 29 auf 30.", steps: ["82 − 30 = 52", "52 + 1 = ?"], shot: "06-hint-round.png" },
+    { op: "-", a: 45, b: 17, rule: "not close, so bridge instead of counting up",
+      title: "Gehe zuerst auf die Zehn.", steps: ["45 − 10 = 35", "35 − 5 = 30", "30 − 2 = ?"], shot: null },
+    { op: "-", a: 10, b: 7, rule: "number pair to ten",
+      title: "Zähle von 7 hinauf bis 10.", steps: ["7 + ? = 10"], shot: null },
+    { op: "-", a: 60, b: 45, rule: "tens away, then out of the last ten",
+      title: "Ziehe zuerst die Zehner ab.", steps: ["60 − 40 = 20", "10 − 5 = 5", "10 + 5 = ?"], shot: null },
+    { op: "+", a: 45, b: 19, rule: "plus close to a whole ten, round and take back",
+      title: "Runde die 19 auf 20.", steps: ["45 + 20 = 65", "65 − 1 = ?"], shot: "08-hint-plus-round.png" },
+    { op: "+", a: 8, b: 7, rule: "plus crossing a ten, fill up",
+      title: "Fülle zuerst auf die nächste Zehn.", steps: ["8 + 2 = 10", "10 + 5 = ?"], shot: null }
+  ];
+
+  for (const c of CASES) {
+    const sign = c.op === "+" ? "+" : "−";
+    await page.click("#change-settings");
+    await page.click(`#op-chips button[data-op="${c.op}"]`);
+    await page.click('#range-chips button[data-min="0"][data-max="100"]');
+    await forceProblem(c.op, c.a, c.b, 100);
+    await page.click("#start");
+    check(`task forced to ${c.a} ${sign} ${c.b}`,
+      (await page.textContent("#problem")).trim() === `${c.a} ${sign} ${c.b} =`,
+      await page.textContent("#problem"));
+    check(`${c.a} ${sign} ${c.b}: hint stays closed until asked`,
+      (await page.textContent("#hint")).trim() === ""
+      && await page.getAttribute("#hint-toggle", "aria-expanded") === "false");
+    await page.click("#hint-toggle");
+    check(`${c.a} ${sign} ${c.b}: ${c.rule}`,
+      (await page.textContent(".hint-title")) === c.title, await page.textContent(".hint-title"));
+    check(`${c.a} ${sign} ${c.b}: steps`,
+      (await hintSteps()).join(" | ") === c.steps.join(" | "), (await hintSteps()).join(" | "));
+    const answer = c.op === "+" ? c.a + c.b : c.a - c.b;
+    check(`${c.a} ${sign} ${c.b}: the answer stays the learner's move`,
+      !new RegExp(`(^|\\D)${answer}(\\D|$)`).test(await page.textContent("#hint")),
+      await page.textContent("#hint"));
+    if (c.shot) await page.screenshot({ path: join(SHOTS_DIR, c.shot) });
+  }
+
   check("hint region is a status region (WCAG 4.1.3)", await page.getAttribute("#hint", "role") === "status");
   check("toggle reports the expanded state", await page.getAttribute("#hint-toggle", "aria-expanded") === "true");
-  await page.screenshot({ path: join(SHOTS_DIR, "06-hint-minus-small.png") });
   await page.click("#hint-toggle");
   check("hint can be collapsed again",
     (await page.textContent("#hint")).trim() === ""
     && await page.getAttribute("#hint-toggle", "aria-expanded") === "false");
 
-  await typeAnswer("38");
-  await forceProblem("-", 45, 17, 100);
-  await page.click("#next");
-  check("second forced problem is 45 − 17", (await page.textContent("#problem")).trim() === "45 − 17 =");
-  await page.click("#hint-toggle");
-  check("45 − 17 counts up from the subtrahend",
-    (await hintSteps()).join(" | ") === "17 + 3 = 20 | 20 + 25 = 45 | Zusammen: 3 + 25 = ?");
-  check("counting-up hint leaves the answer open", !(await page.textContent("#hint")).includes("28"));
-  await page.screenshot({ path: join(SHOTS_DIR, "07-hint-minus-crossing.png") });
+  // The hint is available before any wrong answer: nothing above asked
+  // for one, and every task opened it straight from the toggle.
 
   // Enter on a focused button does that button's job and nothing else,
   // even while Weiter is on screen and listening for Enter.
-  await page.click("#hint-toggle");
+  await page.click("#change-settings");
+  await page.click('#op-chips button[data-op="-"]');
+  await forceProblem("-", 45, 17, 100);
+  await page.click("#start");
   await typeAnswer("28");
   await forceProblems([["-", 45, 7, 100], ["-", 20, 5, 100]]);
   await page.focus("#hint-toggle");
@@ -288,11 +320,6 @@ try {
   await page.click('#range-chips button[data-min="0"][data-max="20"]');
   await forceProblem("+", 8, 7, 20);
   await page.click("#start");
-  check("plus problem forced to 8 + 7", (await page.textContent("#problem")).trim() === "8 + 7 =");
-  await page.click("#hint-toggle");
-  check("8 + 7 fills up to the next ten",
-    (await hintSteps()).join(" | ") === "8 + 2 = 10 | 10 + 5 = ?");
-  await page.click("#hint-toggle");
 
   // Second miss opens the hint by itself.
   for (let i = 0; i < 2; i++) {
@@ -304,7 +331,7 @@ try {
     && (await page.textContent(".hint-title")).length > 0);
   check("feedback points at the hint instead of repeating it",
     (await page.textContent("#feedback")).includes("Rechenweg"));
-  await page.screenshot({ path: join(SHOTS_DIR, "08-hint-after-second-miss.png") });
+  await page.screenshot({ path: join(SHOTS_DIR, "09-hint-after-second-miss.png") });
   for (const _ of "16") await page.click("#backspace");
   await typeAnswer("15");
   check("solving after the hint still counts and pays full XP",
@@ -358,7 +385,7 @@ try {
   check("reset is announced in a status region",
     await page.getAttribute("#reset-status", "role") === "status"
     && (await page.textContent("#reset-status")).length > 0);
-  await page.screenshot({ path: join(SHOTS_DIR, "09-reset.png"), fullPage: true });
+  await page.screenshot({ path: join(SHOTS_DIR, "10-reset.png"), fullPage: true });
   await page.click("#show-medals");
   check("medals are locked again after the reset",
     await page.evaluate(() => document.querySelectorAll(".medal.locked").length === 8));


### PR DESCRIPTION
The hint engine picked its strategy by looking at the digits first, which sent `82 − 31` down a plain counting hint and never used the rounding trick for `82 − 29`. It now walks the questions a child would actually ask, in order, and the first one that fits decides.

## Minus

| # | Question | Way | Example |
| --- | --- | --- | --- |
| 1 | Is the number to take away close to the first one, at most 10 below it? | Count up from it | `25 − 17` → 17 + 3 = 20, 20 + 5 = 25, Zusammen: 3 + 5 = ? |
| 2 | Is it 1 or 2 below a whole ten? | Round it up, give the rest back | `82 − 29` → 82 − 30 = 52, 52 + 1 = ? |
| 3 | Do the ones cross a ten? | Go over the ten in steps | `42 − 7` → 42 − 2 = 40, 40 − 5 = ? |
| 4 | Otherwise | Tens first, then ones | `82 − 31` → 82 − 30 = 52, 52 − 1 = ? |

Question 1 asks about closeness, not size, which changes one case from the previous round: `45 − 17` is 28 apart, so it now bridges in three steps (45 − 10 = 35, 35 − 5 = 30, 30 − 2 = ?) instead of counting up from 17.

## Plus

The same order without question 1, which has no meaning for addition. That hands plus the rounding trick too: `45 + 19` → 45 + 20 = 65, 65 − 1 = ?, and `45 + 9` → 45 + 10 = 55, 55 − 1 = ?. Crossing tasks still fill up to the ten (`8 + 7`), and the rest still goes tens before ones. This part was not in the request; say the word and I will drop it back to the old plus behavior.

## Corners the questions exposed

- A task standing exactly on 10 is the number pair to ten: `10 − 7` → 7 + ? = 10, instead of degenerating into "10 − 10 = 0, 0 + 3 = ?".
- A whole ten plus a single digit names the place value instead of printing "0 + 3 = ?".

## On demand

The toggle was already in the merged build and opens at any time, before any wrong answer. The second miss still opens it by itself. Every case in the test table opens it straight from the toggle with a clean slate.

## Verification

- Every hint now carries the id of the rule that produced it. The checker walks all 1,016,550 tasks across the presets and the 0-1000 custom range and holds five properties: the chosen rule is the one the four questions ask for, every step is arithmetically true, exactly the last step stays open with "?", no step starts from a pointless zero, and no hint runs past three steps.
- `add-subtract/tests/e2e.test.mjs` drives nine forced tasks through the real UI, one per rule, asserting the title and every step: the four cases from the request plus `45 − 17`, `10 − 7`, `60 − 45`, `45 + 19`, `8 + 7`. All checks pass, no console errors.
- Cache buster bumped to `?v=5`.
- PRD, README and the app CLAUDE.md updated in the same change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpYnVTCzBBTURM3GiggCF1)_