### PR TITLE
Align the sentence comparison, and say which sentence is being written

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ A calm spelling trainer for kids, built on one Lehrplan 21 competency (D.4 Schre
 - 22 rules, 66 chapters, 484 tasks across the three cycles, plus 9 texts of 42 sentences
 - Three chapters per rule that rise in difficulty and always end in writing: tap the answer, then tap a harder one, then type it yourself
 - A writing-only mode: whole texts written out sentence by sentence, mixing capitals, end marks and commas, with the paragraph taking shape on screen
-- Seven kinds of task: letters missing in a word, a word missing from a sentence, a punctuation mark, the missing word typed out, a whole sentence written correctly, and memory words written from memory
+- Seven kinds of task: letters missing in a word, a word missing from a sentence, a punctuation mark, the missing word typed out, a whole sentence written correctly, memory words written from memory, and one sentence of a text in the writing mode
 - Rules that straddle a cycle boundary in the source appear on both cycle lists and share one set of counters
 - Distractors are the mistakes children really make (`Schport`, `Beischpiel`), so only the rule decides
-- Written answers check themselves on the last character, no confirm button
+- A written word checks itself on the last character; a written sentence is judged as soon as it looks finished, with a Fertig button for anything still ambiguous, and a wrong sentence comes back word by word so one missing comma marks one word
 - Supportive feedback that stays on screen, with the rule shown once the answer is in
 - Quiet gamification: XP, levels and eleven medals that reward practice, never speed or perfection
 - After five clean rounds the app suggests the next cycle, and never forces it; no chapter is ever locked

--- a/wortwerkstatt/CLAUDE.md
+++ b/wortwerkstatt/CLAUDE.md
@@ -103,14 +103,27 @@ All enforced by the e2e suite unless noted:
 - **A word checks itself; a sentence is confirmed** (`needsConfirm`,
   `CONFIRM_KINDS`). The known-length pattern needs a length the child
   can actually count. `memory` and `write` auto-check on the last
-  character with the count stated. `copy` and `text` get a Fertig button
-  and Enter, because a sentence one character short never reaches the
-  expected length and would hang forever with no feedback — the bug this
-  rule exists to prevent. **Never move a sentence kind to auto-check.**
-  Confirmed fields also allow overshoot, so a too-long answer stays
-  finishable. Wrong answers come back character by character for a word
-  and **word by word** for a sentence (`wordDiff`), so one missing comma
-  marks one word instead of everything after it. The advisory line under
+  character with the count stated. `copy` and `text` are judged as soon as
+  they **look finished** (`looksComplete`: exactly right, or the same
+  word count ending on a sentence mark), with a Fertig button and Enter
+  for everything else. Without that fallback a sentence one character
+  short never reaches the expected length and hangs forever with no
+  feedback — the bug this rule exists to prevent. **Never widen
+  `looksComplete` to a state a half-typed sentence can reach**; the
+  suite feeds every prefix of every answer through it. Confirmed fields
+  allow overshoot, so a too-long answer stays finishable, and
+  `normaliseTyped` strips stray spacing before anything is judged. A
+  retry keeps a sentence, so the child fixes the marked word instead of
+  retyping 45 characters; a single word starts fresh. Wrong answers come back character by character for a word
+  and **word by word** for a sentence. `wordDiff` **aligns** the two
+  (longest common subsequence) rather than comparing positions: a
+  positional walk turns the whole tail red as soon as one word is
+  dropped. **Never replace it with a positional compare**; the suite
+  requires that a small first letter, a word left out and a word too
+  many each mark exactly one thing in every text sentence.
+  In the writing mode the sentence in hand is named in the instruction
+  and pointed at with a chevron — without that a child writes the wrong
+  line of the paragraph and every word comes back wrong. The advisory line under
   the field says which of the two applies (WCAG 3.2.2). `autocapitalize="none"` and
   `spellcheck="false"` are load-bearing — capitals are the lesson and
   the browser must not spell it for the child. The `input` handler must

--- a/wortwerkstatt/PRD.md
+++ b/wortwerkstatt/PRD.md
@@ -174,6 +174,11 @@ words, and no other part of the app asks for a whole text.
 
 - Nine texts, three per cycle, 42 sentences in total. A text is 4 to 5
   sentences and names on its card which rules it pulls together.
+- **The sentence being written is named and pointed at.** The
+  instruction reads "Schreib Satz 1 von 4 richtig auf." and a chevron
+  marks the line in hand. Five similar-looking lines with only a tint
+  between them is not enough: write the wrong line and every word comes
+  back wrong, which reads as a broken app rather than a misread.
 - The text is written **one sentence at a time, in order**. A paragraph
   that shuffles is not a paragraph, so a text round is as long as the
   text rather than `ROUND_SIZE`.
@@ -259,10 +264,21 @@ right one.
 
 **How a wrong answer comes back** depends on the same split. A single
 word is shown back character by character, because its letters are the
-lesson. A sentence is shown back **word by word**: one missing comma
-shifts every later character, and a wall of red for a single slip tells
-a child nothing. By word, a missing comma marks exactly `wusste,` and
-nothing else.
+lesson. A sentence is shown back **word by word**, and the two sentences
+are **aligned** rather than compared position by position.
+
+Position by position, one word dropped in the middle shifts everything
+after it and the rest of the sentence turns red — which tells a child
+nothing except that they failed. Aligned (`wordDiff`, longest common
+subsequence), a word they got right stays right whatever happened
+around it, a dropped word shows as a gap where it belongs, and an extra
+word is marked on its own. A dropped word immediately followed by an
+unexpected one collapses into a single mark, because that is one word
+written differently, not one lost and one gained.
+
+The suite holds this to one mark per slip: for every sentence in the
+pack, a small first letter, a word left out and a word too many must
+each mark exactly one thing, and a right sentence must mark nothing.
 
 
 - **Choice tasks**: large option buttons, no confirm step. A single

--- a/wortwerkstatt/README.md
+++ b/wortwerkstatt/README.md
@@ -30,7 +30,8 @@ stehen darum auf beiden Listen.
    aussieht: wenn er stimmt, oder wenn er gleich viele Wörter hat und
    mit einem Satzzeichen endet. Sonst tippst du auf Fertig. Stimmt
    etwas nicht, siehst du genau, welches Wort, und dein Satz bleibt
-   stehen, damit du nur das eine Wort ändern musst.
+   stehen, damit du nur das eine Wort ändern musst. Ein Fehler färbt
+   immer nur ein Wort, auch wenn er am Anfang des Satzes steht.
 7. Nach der Antwort erscheint die Regel. Vorher wäre sie nur eine
    Tabelle zum Abschreiben.
 8. Für jede Runde gibt es XP, Levels (vom Schreiblehrling zur
@@ -47,7 +48,8 @@ ganzen Text richtig auf, Satz für Satz. Der Text steht als schnell
 getippter Entwurf da, ganz klein geschrieben und ohne Satzzeichen. Du
 setzt die grossen Buchstaben, die Satzzeichen und die Kommas.
 
-Der Text wächst dabei vor deinen Augen: Was du geschrieben hast, steht
+Über dem Text steht, welchen Satz du gerade schreibst, und ein Pfeil
+zeigt auf die Zeile. Der Text wächst dabei vor deinen Augen: Was du geschrieben hast, steht
 schon richtig da, der Satz an der Reihe ist hervorgehoben, der Rest
 wartet noch.
 

--- a/wortwerkstatt/css/styles.css
+++ b/wortwerkstatt/css/styles.css
@@ -6,14 +6,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=4") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=5") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=4") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=5") format("woff2");
 }
 
 :root {
@@ -965,4 +965,25 @@ h1, h2, h3 {
   color: var(--color-danger);
   text-decoration: underline;
   text-decoration-thickness: 2px;
+}
+
+/* The line being written is pointed at, so it cannot be mistaken for
+   one of the lines around it. */
+.para-line.current {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.para-line.current .icon {
+  align-self: center;
+  color: var(--color-accent);
+}
+
+/* A word the child left out: the gap is shown where it belongs rather
+   than shifting every later word out of place. */
+.word:empty::before,
+.word.gap::before {
+  content: "·";
+  color: var(--color-danger);
 }

--- a/wortwerkstatt/index.html
+++ b/wortwerkstatt/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Wortwerkstatt: Rechtschreibung üben nach Lehrplan 21, Regel für Regel.">
   <title>Wortwerkstatt</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=4">
+  <link rel="stylesheet" href="css/styles.css?v=5">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Wortwerkstatt braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=4"></script>
+  <script type="module" src="js/app.js?v=5"></script>
 </body>
 </html>

--- a/wortwerkstatt/js/app.js
+++ b/wortwerkstatt/js/app.js
@@ -1,17 +1,17 @@
 // app.js — controller: owns the state, handles all interactions via
 // event delegation, persists through storage.js and renders via ui.js.
 
-import { render } from "./ui.js?v=4";
+import { render } from "./ui.js?v=5";
 import {
   topicById, chapterById, chaptersForCycle, topicKey, textById, textKey
-} from "./data.js?v=4";
-import { t, setLanguage } from "./i18n.js?v=4";
-import * as storage from "./storage.js?v=4";
+} from "./data.js?v=5";
+import { t, setLanguage } from "./i18n.js?v=5";
+import * as storage from "./storage.js?v=5";
 import {
   buildRound, buildTextRound, isCorrect, needsStudyStep, expectedAnswer,
   isTyped, needsConfirm, looksComplete, normaliseTyped
-} from "./round.js?v=4";
-import { award, xpForRound } from "./game.js?v=4";
+} from "./round.js?v=5";
+import { award, xpForRound } from "./game.js?v=5";
 
 // Consecutive clean rounds before the app offers the next cycle. The
 // offer is a suggestion, never a forced step (GAMIFICATION.md).

--- a/wortwerkstatt/js/data.js
+++ b/wortwerkstatt/js/data.js
@@ -2,7 +2,7 @@
 // three Lehrplan 21 cycles. No copy lives here; everything visible
 // resolves through the string tables in js/i18n/.
 
-import { de as contentDe } from "./content/de.js?v=4";
+import { de as contentDe } from "./content/de.js?v=5";
 
 export const LANGUAGES = [
   { code: "de", htmlLang: "de-CH", label: "Deutsch" },

--- a/wortwerkstatt/js/game.js
+++ b/wortwerkstatt/js/game.js
@@ -5,7 +5,7 @@
 // never matters. Medal checks are pure functions of the data object so
 // they can never drift from the stored state.
 
-import { topicsForCycle, contentByCode } from "./data.js?v=4";
+import { topicsForCycle, contentByCode } from "./data.js?v=5";
 
 // Cumulative XP thresholds. Beyond the last level XP keeps counting.
 export const LEVELS = [

--- a/wortwerkstatt/js/i18n.js
+++ b/wortwerkstatt/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=4";
-import { de } from "./i18n/de.js?v=4";
-import { en } from "./i18n/en.js?v=4";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=5";
+import { de } from "./i18n/de.js?v=5";
+import { en } from "./i18n/en.js?v=5";
 
 export const TABLES = { de, en };
 

--- a/wortwerkstatt/js/i18n/de.js
+++ b/wortwerkstatt/js/i18n/de.js
@@ -153,7 +153,7 @@ export const de = {
   textRounds: "{n} mal geschrieben",
   textRules: "Übt: {rules}",
   textProgress: "Satz {i} von {n}",
-  instructionText: "Schreib den Satz richtig auf.",
+  instructionText: "Schreib Satz {i} von {n} richtig auf.",
   textIntro: "So hat es jemand schnell getippt. Setz die grossen Buchstaben, die Satzzeichen und die Kommas.",
   medalNameTextschreiber: "Textschreiber",
   medalDescTextschreiber: "Drei ganze Texte geschrieben.",

--- a/wortwerkstatt/js/i18n/en.js
+++ b/wortwerkstatt/js/i18n/en.js
@@ -153,7 +153,7 @@ export const en = {
   textRounds: "written {n} times",
   textRules: "Practises: {rules}",
   textProgress: "Sentence {i} of {n}",
-  instructionText: "Write the sentence correctly.",
+  instructionText: "Write sentence {i} of {n} correctly.",
   textIntro: "This is how someone typed it in a hurry. Add the capital letters, the end marks and the commas.",
   medalNameTextschreiber: "Text Writer",
   medalDescTextschreiber: "Wrote three whole texts.",

--- a/wortwerkstatt/js/round.js
+++ b/wortwerkstatt/js/round.js
@@ -4,7 +4,7 @@
 // module directly to derive the expected answers, so the tests can
 // never drift from the engine.
 
-import { shuffle } from "./util.js?v=4";
+import { shuffle } from "./util.js?v=5";
 
 export const ROUND_SIZE = 6;
 
@@ -66,19 +66,62 @@ export function looksComplete(expected, typed) {
 
 // Only the memory kind hides the answer first and asks for it back.
 // Write derives it from the rule, copy has it on screen the whole time.
-// Which words of a sentence are right, word by word. A sentence is
-// compared by word rather than by character on purpose: one missing
-// comma shifts every later character, and a wall of red for a single
-// slip tells a child nothing. By word, a missing comma marks exactly
-// "wusste," and nothing else.
+// Which of the child's words are right.
+//
+// The comparison aligns the two sentences rather than walking them
+// position by position. Position by position, one word dropped in the
+// middle shifts everything after it and the rest of the sentence turns
+// red, which tells a child nothing except that they failed. Aligned, a
+// word they got right stays right no matter what happened around it.
+//
+// A dropped word immediately followed by an unexpected one is one word
+// written differently, not one lost and one gained, so the two collapse
+// into a single marked word.
 export function wordDiff(expected, typed) {
-  const want = expected.split(" ");
-  const got = typed.trim() === "" ? [] : typed.split(/\s+/);
-  const rows = [];
-  for (let i = 0; i < Math.max(want.length, got.length); i++) {
-    rows.push({ word: got[i] === undefined ? "" : got[i], ok: got[i] === want[i] });
+  const want = splitWords(expected);
+  const got = splitWords(typed);
+  const n = want.length;
+  const m = got.length;
+
+  // Longest common subsequence over the suffixes of both sentences.
+  const lcs = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = want[i] === got[j]
+        ? lcs[i + 1][j + 1] + 1
+        : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
   }
-  return rows;
+
+  const rows = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (want[i] === got[j]) rows.push({ word: got[j++], ok: true, i: i++ });
+    else if (lcs[i + 1][j] >= lcs[i][j + 1]) rows.push({ word: "", ok: false, dropped: true, i: i++ });
+    else rows.push({ word: got[j++], ok: false });
+  }
+  while (j < m) rows.push({ word: got[j++], ok: false });
+  while (i < n) rows.push({ word: "", ok: false, dropped: true, i: i++ });
+
+  const merged = [];
+  for (let k = 0; k < rows.length; k++) {
+    const a = rows[k];
+    const b = rows[k + 1];
+    const pair = b && !a.ok && !b.ok && a.dropped !== b.dropped;
+    if (pair) {
+      merged.push({ word: a.dropped ? b.word : a.word, ok: false });
+      k += 1;
+    } else {
+      merged.push({ word: a.word, ok: a.ok });
+    }
+  }
+  return merged;
+}
+
+function splitWords(value) {
+  const t = normaliseTyped(value);
+  return t === "" ? [] : t.split(" ");
 }
 
 export function needsStudyStep(task) {

--- a/wortwerkstatt/js/storage.js
+++ b/wortwerkstatt/js/storage.js
@@ -4,7 +4,7 @@
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   DEFAULT_LANGUAGE, DEFAULT_CONTENT_LANGUAGE, DEFAULT_CYCLE
-} from "./data.js?v=4";
+} from "./data.js?v=5";
 
 const KEY = "wortwerkstatt.state";
 

--- a/wortwerkstatt/js/ui.js
+++ b/wortwerkstatt/js/ui.js
@@ -4,18 +4,18 @@
 // i18n; every practice string comes from the content pack and is
 // marked with the content language so screen readers switch voice.
 
-import { icon } from "./icons.js?v=4";
+import { icon } from "./icons.js?v=5";
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   contentByCode, topicsForCycle, topicById, topicKey,
   textsForCycle, textById, textKey, LEHRPLAN_VERSION
-} from "./data.js?v=4";
-import { t, currentLanguage } from "./i18n.js?v=4";
-import { escapeHtml, statusOf, topicStatus } from "./util.js?v=4";
+} from "./data.js?v=5";
+import { t, currentLanguage } from "./i18n.js?v=5";
+import { escapeHtml, statusOf, topicStatus } from "./util.js?v=5";
 import {
   fillTask, expectedAnswer, letterDiff, wordDiff, isTyped, needsConfirm, ROUND_SIZE
-} from "./round.js?v=4";
-import { MEDALS, levelFor } from "./game.js?v=4";
+} from "./round.js?v=5";
+import { MEDALS, levelFor } from "./game.js?v=5";
 
 // Sentinel put in place of the answer so the blank lands exactly where
 // round.js says it does, spacing included. A control character, because
@@ -402,6 +402,11 @@ function renderRound(state) {
 }
 
 function instructionFor(task, r) {
+  // A paragraph of similar-looking lines needs the task named, or a
+  // child writes the wrong line and every word comes back wrong.
+  if (task.kind === "text") {
+    return t("instructionText", { i: r.i + 1, n: r.tasks.length });
+  }
   if (task.kind === "memory") {
     return r.phase === "study" ? t("instructionMemoryStudy") : t("instructionMemoryWrite");
   }
@@ -561,7 +566,9 @@ function paragraph(state, r, shown) {
       return `<span class="para-line done">${escapeHtml(task.item.answer)}</span>`;
     }
     if (i === r.i) {
-      return `<span class="para-line current">${escapeHtml(task.item.prompt)}</span>`;
+      // The line in hand is pointed at, not just tinted: colour alone
+      // would not separate it from four lines that look the same.
+      return `<span class="para-line current">${icon("chevron-right")}<span>${escapeHtml(task.item.prompt)}</span></span>`;
     }
     return `<span class="para-line pending">${escapeHtml(task.item.prompt)}</span>`;
   }).join("");

--- a/wortwerkstatt/tests/e2e.test.mjs
+++ b/wortwerkstatt/tests/e2e.test.mjs
@@ -22,13 +22,13 @@ import { fileURLToPath } from "node:url";
 import {
   CONTENT_LANGUAGES, CYCLES, topicsForCycle, topicKey,
   textsForCycle, textKey, LEHRPLAN_VERSION
-} from "../js/data.js?v=4";
-import { TABLES } from "../js/i18n.js?v=4";
+} from "../js/data.js?v=5";
+import { TABLES } from "../js/i18n.js?v=5";
 import {
   fillTask, expectedAnswer, solutionText, isTyped, needsConfirm, wordDiff,
   looksComplete, ROUND_SIZE
-} from "../js/round.js?v=4";
-import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=4";
+} from "../js/round.js?v=5";
+import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=5";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -258,6 +258,29 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   }
   check("no half-typed sentence is ever judged on its own", halfProblems.length === 0,
     halfProblems.slice(0, 4).join(" | "));
+
+  // Marking is aligned, not positional. One slip must cost one mark,
+  // however early in the sentence it happens, or a child sees a wall of
+  // red and learns nothing from it.
+  const markProblems = [];
+  for (const item of CONTENT.texts.flatMap((text) => text.sentences)) {
+    const words = item.answer.split(" ");
+    if (words.length < 4) continue;
+    const cases = [
+      ["a small first letter", words.map((w, k) => (k ? w : w.toLowerCase())).join(" ")],
+      ["a word left out", words.filter((_, k) => k !== 1).join(" ")],
+      ["a word too many", [...words.slice(0, 2), "sehr", ...words.slice(2)].join(" ")]
+    ];
+    for (const [name, typed] of cases) {
+      const red = wordDiff(item.answer, typed).filter((w) => !w.ok).length;
+      if (red !== 1) markProblems.push(`${item.answer} with ${name}: ${red} marked`);
+    }
+    if (wordDiff(item.answer, item.answer).some((w) => !w.ok)) {
+      markProblems.push(`${item.answer}: marked despite being right`);
+    }
+  }
+  check("one slip marks one word, in every text sentence", markProblems.length === 0,
+    markProblems.slice(0, 4).join(" | "));
   const perCycle = CYCLES.map((c) => textsForCycle(CONTENT.code, c).length);
   check("every cycle has texts to write", perCycle.every((n) => n > 0), perCycle.join("/"));
 }
@@ -618,6 +641,13 @@ try {
     (await count(".para-line.pending")) === firstText.sentences.length - 1);
   check("nothing is shown as finished yet", (await count(".para-line.done")) === 0);
   check("the mode says what has to be added", (await text(".task-clue")).includes("grossen Buchstaben"));
+  // A paragraph of similar lines has to say which one is being asked,
+  // or a child writes the wrong line and every word comes back wrong.
+  check("the instruction names which sentence is being written",
+    (await text(".instruction")) === `Schreib Satz 1 von ${firstText.sentences.length} richtig auf.`,
+    await text(".instruction"));
+  check("the line in hand is pointed at, not only tinted",
+    (await count(".para-line.current .icon")) === 1);
   await shot("27-text-start");
 
   // A miss first: the letter comparison has to work on a whole sentence.
@@ -625,8 +655,11 @@ try {
   check("a wrong sentence is answered at once", (await count(".feedback-warn")) === 1);
   // A sentence comes back by word: a single slip must not paint every
   // later character red.
+  // Cell count comes from the aligner, not from the sentence length: a
+  // dropped word shows a gap, so the two need not match.
+  const backCells = wordDiff(firstText.sentences[0].answer, firstText.sentences[0].prompt + ".").length;
   check("the whole sentence is shown back word by word",
-    (await count(".word")) === firstText.sentences[0].answer.split(" ").length);
+    (await count(".word")) === backCells, `${await count(".word")} cells, expected ${backCells}`);
   check("the missed words are marked", (await count(".word.miss")) > 0);
   check("a sentence is never shown back character by character",
     (await count(".letter")) === 0);


### PR DESCRIPTION
Fixes a reported "too much red": writing a sentence in the text mode marked almost every word wrong, including words that were right.

**Live once merged:** https://lfdave.github.io/small-apps/wortwerkstatt/index.html?r=20260803-5

## Two causes, both interface faults

**1. The paragraph never said which line was being asked.** Five similar lines separated only by a tint. In the reported screenshot the current sentence was line 1 (`das lernen fiel ihm diesmal leicht`) but the text typed was line 2 — so *every* word was genuinely wrong, and `am` really is correct, just in a different sentence. Writing the wrong line marking everything red reads as a broken app rather than a misread.

The instruction now names it — **"Schreib Satz 1 von 4 richtig auf."** — and a chevron points at the line in hand.

**2. The comparison was positional.** One word dropped in the middle shifted everything after it and the rest of the sentence went red. `wordDiff` now **aligns** the two sentences (longest common subsequence):

| Typed | Before | Now |
|---|---|---|
| small first letter | 1 marked | 1 marked |
| missing comma | 1 marked | 1 marked |
| **a word left out** | **every later word** | 1 gap marked |
| **a word too many** | **every later word** | 1 marked |

A word the child got right stays right whatever happened around it; a dropped word shows as a gap where it belongs. A dropped word immediately followed by an unexpected one collapses into a single mark, because that is one word written differently, not one lost and one gained — otherwise a plain capitalisation slip would cost two cells.

## Testing

**186 checks pass.** The new guard runs over **every sentence in the pack**: a small first letter, a word left out and a word too many must each mark exactly one thing, and a right sentence must mark nothing. Plus browser checks that the instruction names the sentence and the current line carries its marker.

## Also: two stale docs corrected

Both outlived the behaviour they described, and would have misled the next change:

- `wortwerkstatt/CLAUDE.md` still said *"Never move a sentence kind to auto-check"* — the opposite of what now ships. (A doc edit in the previous PR silently failed to match its anchor.)
- The root `README.md` still said *"Written answers check themselves on the last character, no confirm button."*

Neither affects behaviour; both are now accurate, and CLAUDE.md records the alignment rule as load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1)_