### PR TITLE
Only draw a gap where a word is genuinely missing

### DIFF
--- a/wortwerkstatt/CLAUDE.md
+++ b/wortwerkstatt/CLAUDE.md
@@ -121,6 +121,12 @@ All enforced by the e2e suite unless noted:
   dropped. **Never replace it with a positional compare**; the suite
   requires that a small first letter, a word left out and a word too
   many each mark exactly one thing in every text sentence.
+  `wordDiff` returns `{rows, missing}`. A **gap cell is only ever drawn
+  where nothing was written in its place**; where words were replaced
+  too, the missing word's position is a guess, so it goes into `missing`
+  and is said in words. Do not draw gaps straight from the raw
+  alignment — the dots land where nothing is missing and the marking
+  reads as noise.
   In the writing mode the sentence in hand is named in the instruction
   and pointed at with a chevron — without that a child writes the wrong
   line of the paragraph and every word comes back wrong. The advisory line under

--- a/wortwerkstatt/PRD.md
+++ b/wortwerkstatt/PRD.md
@@ -271,10 +271,20 @@ Position by position, one word dropped in the middle shifts everything
 after it and the rest of the sentence turns red — which tells a child
 nothing except that they failed. Aligned (`wordDiff`, longest common
 subsequence), a word they got right stays right whatever happened
-around it, a dropped word shows as a gap where it belongs, and an extra
-word is marked on its own. A dropped word immediately followed by an
-unexpected one collapses into a single mark, because that is one word
-written differently, not one lost and one gained.
+around it.
+
+Between two words that match, the child's unmatched words are paired
+against the expected ones that went with them: those are words written
+differently, not words lost and words gained, so each shows as one mark
+carrying **what the child actually wrote**.
+
+**A gap is only drawn where it is genuinely known** — a stretch with
+words expected and nothing written in their place. Where words were
+replaced as well, the position of a missing word is a guess, so it is
+counted and said in words ("Ein Wort fehlt noch.") instead of drawn
+somewhere it probably does not belong. Dots scattered through a
+sentence that also has replacements point at spots where nothing is
+missing, which reads as noise.
 
 The suite holds this to one mark per slip: for every sentence in the
 pack, a small first letter, a word left out and a word too many must

--- a/wortwerkstatt/css/styles.css
+++ b/wortwerkstatt/css/styles.css
@@ -6,14 +6,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=5") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=6") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=5") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=6") format("woff2");
 }
 
 :root {
@@ -982,7 +982,6 @@ h1, h2, h3 {
 
 /* A word the child left out: the gap is shown where it belongs rather
    than shifting every later word out of place. */
-.word:empty::before,
 .word.gap::before {
   content: "·";
   color: var(--color-danger);

--- a/wortwerkstatt/index.html
+++ b/wortwerkstatt/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Wortwerkstatt: Rechtschreibung üben nach Lehrplan 21, Regel für Regel.">
   <title>Wortwerkstatt</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=5">
+  <link rel="stylesheet" href="css/styles.css?v=6">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Wortwerkstatt braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=5"></script>
+  <script type="module" src="js/app.js?v=6"></script>
 </body>
 </html>

--- a/wortwerkstatt/js/app.js
+++ b/wortwerkstatt/js/app.js
@@ -1,17 +1,17 @@
 // app.js — controller: owns the state, handles all interactions via
 // event delegation, persists through storage.js and renders via ui.js.
 
-import { render } from "./ui.js?v=5";
+import { render } from "./ui.js?v=6";
 import {
   topicById, chapterById, chaptersForCycle, topicKey, textById, textKey
-} from "./data.js?v=5";
-import { t, setLanguage } from "./i18n.js?v=5";
-import * as storage from "./storage.js?v=5";
+} from "./data.js?v=6";
+import { t, setLanguage } from "./i18n.js?v=6";
+import * as storage from "./storage.js?v=6";
 import {
   buildRound, buildTextRound, isCorrect, needsStudyStep, expectedAnswer,
   isTyped, needsConfirm, looksComplete, normaliseTyped
-} from "./round.js?v=5";
-import { award, xpForRound } from "./game.js?v=5";
+} from "./round.js?v=6";
+import { award, xpForRound } from "./game.js?v=6";
 
 // Consecutive clean rounds before the app offers the next cycle. The
 // offer is a suggestion, never a forced step (GAMIFICATION.md).

--- a/wortwerkstatt/js/data.js
+++ b/wortwerkstatt/js/data.js
@@ -2,7 +2,7 @@
 // three Lehrplan 21 cycles. No copy lives here; everything visible
 // resolves through the string tables in js/i18n/.
 
-import { de as contentDe } from "./content/de.js?v=5";
+import { de as contentDe } from "./content/de.js?v=6";
 
 export const LANGUAGES = [
   { code: "de", htmlLang: "de-CH", label: "Deutsch" },

--- a/wortwerkstatt/js/game.js
+++ b/wortwerkstatt/js/game.js
@@ -5,7 +5,7 @@
 // never matters. Medal checks are pure functions of the data object so
 // they can never drift from the stored state.
 
-import { topicsForCycle, contentByCode } from "./data.js?v=5";
+import { topicsForCycle, contentByCode } from "./data.js?v=6";
 
 // Cumulative XP thresholds. Beyond the last level XP keeps counting.
 export const LEVELS = [

--- a/wortwerkstatt/js/i18n.js
+++ b/wortwerkstatt/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=5";
-import { de } from "./i18n/de.js?v=5";
-import { en } from "./i18n/en.js?v=5";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=6";
+import { de } from "./i18n/de.js?v=6";
+import { en } from "./i18n/en.js?v=6";
 
 export const TABLES = { de, en };
 

--- a/wortwerkstatt/js/i18n/de.js
+++ b/wortwerkstatt/js/i18n/de.js
@@ -112,6 +112,8 @@ export const de = {
   feedbackWrongAgain: "Fast. Lies die Regel langsam durch.",
   feedbackReveal: "So wird es geschrieben. Präg es dir ein.",
 
+  wordsMissingOne: "Ein Wort fehlt noch.",
+  wordsMissingMany: "{n} Wörter fehlen noch.",
   actionCheck: "Fertig",
   writeConfirmHint: "Schreib den ganzen Satz.",
   writeAutoHint: "Sobald der Satz fertig aussieht, prüft die App ihn. Sonst tipp auf Fertig.",

--- a/wortwerkstatt/js/i18n/en.js
+++ b/wortwerkstatt/js/i18n/en.js
@@ -112,6 +112,8 @@ export const en = {
   feedbackWrongAgain: "Almost. Read the rule slowly.",
   feedbackReveal: "This is how it is written. Remember it.",
 
+  wordsMissingOne: "One word is still missing.",
+  wordsMissingMany: "{n} words are still missing.",
   actionCheck: "Done",
   writeConfirmHint: "Write the whole sentence.",
   writeAutoHint: "As soon as the sentence looks finished, the app checks it. Otherwise tap Done.",

--- a/wortwerkstatt/js/round.js
+++ b/wortwerkstatt/js/round.js
@@ -4,7 +4,7 @@
 // module directly to derive the expected answers, so the tests can
 // never drift from the engine.
 
-import { shuffle } from "./util.js?v=5";
+import { shuffle } from "./util.js?v=6";
 
 export const ROUND_SIZE = 6;
 
@@ -66,17 +66,22 @@ export function looksComplete(expected, typed) {
 
 // Only the memory kind hides the answer first and asks for it back.
 // Write derives it from the rule, copy has it on screen the whole time.
-// Which of the child's words are right.
+// Which of the child's words are right, and how many are missing.
+// Returns { rows, missing }.
 //
-// The comparison aligns the two sentences rather than walking them
-// position by position. Position by position, one word dropped in the
-// middle shifts everything after it and the rest of the sentence turns
-// red, which tells a child nothing except that they failed. Aligned, a
-// word they got right stays right no matter what happened around it.
+// The two sentences are aligned rather than walked position by
+// position: position by position, one word dropped in the middle
+// shifts everything after it and the rest of the sentence turns red.
 //
-// A dropped word immediately followed by an unexpected one is one word
-// written differently, not one lost and one gained, so the two collapse
-// into a single marked word.
+// Between two words that match, the child's unmatched words are paired
+// against the expected ones that went with them — those are words
+// written differently, not words lost and words gained, so each shows
+// as one mark carrying what the child actually wrote.
+//
+// A gap is only ever drawn where it is genuinely known: a stretch with
+// words expected and nothing written in their place. Where words were
+// replaced as well, the position of the missing one is a guess, so it
+// is counted and said in words instead of drawn in the wrong spot.
 export function wordDiff(expected, typed) {
   const want = splitWords(expected);
   const got = splitWords(typed);
@@ -94,29 +99,42 @@ export function wordDiff(expected, typed) {
   }
 
   const rows = [];
+  let missing = 0;
+  let dropped = [];
+  let added = [];
+
+  const flush = () => {
+    for (const word of added) rows.push({ word, ok: false });
+    const short = dropped.length - added.length;
+    if (short > 0) {
+      if (added.length === 0) {
+        for (let k = 0; k < short; k++) rows.push({ word: "", ok: false, gap: true });
+      } else {
+        missing += short;
+      }
+    }
+    dropped = [];
+    added = [];
+  };
+
   let i = 0;
   let j = 0;
   while (i < n && j < m) {
-    if (want[i] === got[j]) rows.push({ word: got[j++], ok: true, i: i++ });
-    else if (lcs[i + 1][j] >= lcs[i][j + 1]) rows.push({ word: "", ok: false, dropped: true, i: i++ });
-    else rows.push({ word: got[j++], ok: false });
-  }
-  while (j < m) rows.push({ word: got[j++], ok: false });
-  while (i < n) rows.push({ word: "", ok: false, dropped: true, i: i++ });
-
-  const merged = [];
-  for (let k = 0; k < rows.length; k++) {
-    const a = rows[k];
-    const b = rows[k + 1];
-    const pair = b && !a.ok && !b.ok && a.dropped !== b.dropped;
-    if (pair) {
-      merged.push({ word: a.dropped ? b.word : a.word, ok: false });
-      k += 1;
+    if (want[i] === got[j]) {
+      flush();
+      rows.push({ word: got[j++], ok: true });
+      i += 1;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      dropped.push(want[i++]);
     } else {
-      merged.push({ word: a.word, ok: a.ok });
+      added.push(got[j++]);
     }
   }
-  return merged;
+  while (j < m) added.push(got[j++]);
+  while (i < n) dropped.push(want[i++]);
+  flush();
+
+  return { rows, missing };
 }
 
 function splitWords(value) {

--- a/wortwerkstatt/js/storage.js
+++ b/wortwerkstatt/js/storage.js
@@ -4,7 +4,7 @@
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   DEFAULT_LANGUAGE, DEFAULT_CONTENT_LANGUAGE, DEFAULT_CYCLE
-} from "./data.js?v=5";
+} from "./data.js?v=6";
 
 const KEY = "wortwerkstatt.state";
 

--- a/wortwerkstatt/js/ui.js
+++ b/wortwerkstatt/js/ui.js
@@ -4,18 +4,18 @@
 // i18n; every practice string comes from the content pack and is
 // marked with the content language so screen readers switch voice.
 
-import { icon } from "./icons.js?v=5";
+import { icon } from "./icons.js?v=6";
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   contentByCode, topicsForCycle, topicById, topicKey,
   textsForCycle, textById, textKey, LEHRPLAN_VERSION
-} from "./data.js?v=5";
-import { t, currentLanguage } from "./i18n.js?v=5";
-import { escapeHtml, statusOf, topicStatus } from "./util.js?v=5";
+} from "./data.js?v=6";
+import { t, currentLanguage } from "./i18n.js?v=6";
+import { escapeHtml, statusOf, topicStatus } from "./util.js?v=6";
 import {
   fillTask, expectedAnswer, letterDiff, wordDiff, isTyped, needsConfirm, ROUND_SIZE
-} from "./round.js?v=5";
-import { MEDALS, levelFor } from "./game.js?v=5";
+} from "./round.js?v=6";
+import { MEDALS, levelFor } from "./game.js?v=6";
 
 // Sentinel put in place of the answer so the blank lands exactly where
 // round.js says it does, spacing included. A control character, because
@@ -591,11 +591,17 @@ function typedBack(state, task, answer, typed) {
 }
 
 function typedWords(state, answer, typed) {
-  const cells = wordDiff(answer, typed).map(({ word, ok }) =>
-    `<span class="word ${ok ? "ok" : "miss"}">${escapeHtml(word || "\u00b7")}</span>`).join("");
+  const { rows, missing } = wordDiff(answer, typed);
+  const cells = rows.map(({ word, ok, gap }) =>
+    `<span class="word ${ok ? "ok" : "miss"}${gap ? " gap" : ""}">${escapeHtml(word)}</span>`).join("");
+  // Where the missing word's position is a guess, it is said in words
+  // rather than drawn somewhere it probably does not belong.
+  const shortfall = missing === 0 ? ""
+    : `<p class="hint">${missing === 1 ? t("wordsMissingOne") : t("wordsMissingMany", { n: missing })}</p>`;
   return `
     <p class="hint">${t("memoryTypedWords")}</p>
-    <div class="words"${contentLangAttr(state)}>${cells}</div>`;
+    <div class="words"${contentLangAttr(state)}>${cells}</div>
+    ${shortfall}`;
 }
 
 // What the child wrote, letter by letter, with the misses marked. The

--- a/wortwerkstatt/tests/e2e.test.mjs
+++ b/wortwerkstatt/tests/e2e.test.mjs
@@ -22,13 +22,13 @@ import { fileURLToPath } from "node:url";
 import {
   CONTENT_LANGUAGES, CYCLES, topicsForCycle, topicKey,
   textsForCycle, textKey, LEHRPLAN_VERSION
-} from "../js/data.js?v=5";
-import { TABLES } from "../js/i18n.js?v=5";
+} from "../js/data.js?v=6";
+import { TABLES } from "../js/i18n.js?v=6";
 import {
   fillTask, expectedAnswer, solutionText, isTyped, needsConfirm, wordDiff,
   looksComplete, ROUND_SIZE
-} from "../js/round.js?v=5";
-import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=5";
+} from "../js/round.js?v=6";
+import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=6";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -231,10 +231,10 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   for (const item of commaSentences) {
     const without = item.answer.replace(",", "");
     if (without.length >= item.answer.length) commaProblems.push(`${item.answer}: not shorter`);
-    const wrong = wordDiff(item.answer, without).filter((w) => !w.ok);
-    if (wrong.length !== 1) {
-      commaProblems.push(`${item.answer}: ${wrong.length} words marked, expected 1`);
-    }
+    // A mark is either a word shown as wrong or a word reported missing.
+    const { rows, missing } = wordDiff(item.answer, without);
+    const marks = rows.filter((w) => !w.ok).length + missing;
+    if (marks !== 1) commaProblems.push(`${item.answer}: ${marks} marks, expected 1`);
   }
   check(`a missing comma marks one word in all ${commaSentences.length} comma sentences`,
     commaSentences.length > 0 && commaProblems.length === 0, commaProblems.slice(0, 4).join(" | "));
@@ -272,15 +272,33 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
       ["a word too many", [...words.slice(0, 2), "sehr", ...words.slice(2)].join(" ")]
     ];
     for (const [name, typed] of cases) {
-      const red = wordDiff(item.answer, typed).filter((w) => !w.ok).length;
+      const { rows, missing } = wordDiff(item.answer, typed);
+      const red = rows.filter((w) => !w.ok).length + missing;
       if (red !== 1) markProblems.push(`${item.answer} with ${name}: ${red} marked`);
     }
-    if (wordDiff(item.answer, item.answer).some((w) => !w.ok)) {
+    if (wordDiff(item.answer, item.answer).rows.some((w) => !w.ok)) {
       markProblems.push(`${item.answer}: marked despite being right`);
     }
   }
   check("one slip marks one word, in every text sentence", markProblems.length === 0,
     markProblems.slice(0, 4).join(" | "));
+
+  // The reported shape: several words written differently and one word
+  // genuinely left out. A gap may only be drawn where nothing was
+  // written in its place, or the dots land where no word is missing.
+  {
+    const answer = "Das Lernen fiel ihm diesmal leicht.";
+    const { rows, missing } = wordDiff(answer, "das lernen fiel im schwer.");
+    const gaps = rows.filter((w) => w.gap).length;
+    check("replaced words never draw a gap where nothing is missing", gaps === 0, `${gaps} gaps`);
+    check("the word that is genuinely missing is counted instead", missing === 1, String(missing));
+    check("the marks carry back what the child actually wrote",
+      rows.map((w) => w.word).join(" ") === "das lernen fiel im schwer.",
+      rows.map((w) => w.word).join(" "));
+    const pure = wordDiff(answer, "Das Lernen fiel ihm leicht.");
+    check("a word left out with nothing in its place still shows a gap",
+      pure.rows.filter((w) => w.gap).length === 1 && pure.missing === 0);
+  }
   const perCycle = CYCLES.map((c) => textsForCycle(CONTENT.code, c).length);
   check("every cycle has texts to write", perCycle.every((n) => n > 0), perCycle.join("/"));
 }
@@ -657,7 +675,7 @@ try {
   // later character red.
   // Cell count comes from the aligner, not from the sentence length: a
   // dropped word shows a gap, so the two need not match.
-  const backCells = wordDiff(firstText.sentences[0].answer, firstText.sentences[0].prompt + ".").length;
+  const backCells = wordDiff(firstText.sentences[0].answer, firstText.sentences[0].prompt + ".").rows.length;
   check("the whole sentence is shown back word by word",
     (await count(".word")) === backCells, `${await count(".word")} cells, expected ${backCells}`);
   check("the missed words are marked", (await count(".word.miss")) > 0);


### PR DESCRIPTION
Fixes a reported "the red dots don't mark anything": writing `das lernen fiel im schwer.` for `Das Lernen fiel ihm diesmal leicht.` showed three gap dots, none of them where the one missing word belongs.

**Live once merged:** https://lfdave.github.io/small-apps/wortwerkstatt/index.html?r=20260803-6

## What was wrong

The alignment itself was correct, but its output was laid out uselessly. In that sentence only `fiel` matches, so the walk emitted **every dropped word first and every written word after** — the dots clustered at the front, pointing at places where nothing was missing. Four of those words were *replacements* (`das`, `lernen`, `im`, `schwer.`); only `diesmal` was genuinely left out.

## What changes

Between two words that match, the child's unmatched words are now **paired** against the expected ones that went with them. Those are words written differently, not words lost and words gained, so each shows as one mark carrying **what the child actually wrote**.

**A gap is drawn only where it is genuinely known** — a stretch with words expected and nothing written in their place. Where words were replaced as well, the position of a missing word is a guess, so it is counted and stated in words instead of drawn somewhere it probably doesn't belong.

| Typed | Before | Now |
|---|---|---|
| `das lernen fiel im schwer.` | `· das lernen` **fiel** `· · im schwer.` | `[das] [lernen]` **fiel** `[im] [schwer.]` + *"Ein Wort fehlt noch."* |
| `Das Lernen fiel ihm leicht.` | gap in place | gap in place, unchanged |

`wordDiff` now returns `{rows, missing}`.

## Testing

**190 checks pass.** The reported case is pinned directly: replaced words must draw **no** gaps, the genuinely missing word must be counted, and the marks must carry back exactly what the child wrote — plus a check that a word left out with nothing in its place still shows its gap where it belongs.

## A note on the second commit

The doc updates belonging with the fix didn't apply — the PRD anchor had been reworded by an earlier change and the script aborted before reaching `CLAUDE.md`, so both still described gaps being drawn straight from the alignment. That's the third time a silent string-replace has let docs drift from behaviour in this series, so this time I verified the merged text explicitly rather than trusting the edit, and the second commit carries the correction. Both files now state the rule that actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1)_