### PR TITLE
Judge a punctuation mark on its own, not as part of the word

### DIFF
--- a/wortwerkstatt/CLAUDE.md
+++ b/wortwerkstatt/CLAUDE.md
@@ -121,7 +121,12 @@ All enforced by the e2e suite unless noted:
   dropped. **Never replace it with a positional compare**; the suite
   requires that a small first letter, a word left out and a word too
   many each mark exactly one thing in every text sentence.
-  `wordDiff` returns `{rows, missing}`. A **gap cell is only ever drawn
+  `wordDiff` returns `{rows, missing}` over **tokens, not words**: a
+  trailing mark is split off (`splitTokens`), so forgetting a full stop
+  marks the mark and leaves the word before it green. End marks and
+  commas are their own rules here — never fold them back into the word.
+  Marks render in a narrow cell grouped tight against their word so the
+  sentence still reads as one. A **gap cell is only ever drawn
   where nothing was written in its place**; where words were replaced
   too, the missing word's position is a guess, so it goes into `missing`
   and is said in words. Do not draw gaps straight from the raw

--- a/wortwerkstatt/PRD.md
+++ b/wortwerkstatt/PRD.md
@@ -267,6 +267,15 @@ word is shown back character by character, because its letters are the
 lesson. A sentence is shown back **word by word**, and the two sentences
 are **aligned** rather than compared position by position.
 
+**A punctuation mark is judged on its own**, not as part of the word it
+hangs off. Writing `leicht` for `leicht.` spells the word perfectly and
+forgets the full stop; marking the word red would say the child got the
+word wrong and hide which of the two rules they actually missed. End
+marks and commas are their own lesson in this app, so they are their own
+token, rendered in their own narrow cell tight against the word so the
+sentence still reads as a sentence. A missing comma now leaves `wusste`
+green and puts the gap where the comma belongs.
+
 Position by position, one word dropped in the middle shifts everything
 after it and the rest of the sentence turns red — which tells a child
 nothing except that they failed. Aligned (`wordDiff`, longest common

--- a/wortwerkstatt/README.md
+++ b/wortwerkstatt/README.md
@@ -31,7 +31,9 @@ stehen darum auf beiden Listen.
    mit einem Satzzeichen endet. Sonst tippst du auf Fertig. Stimmt
    etwas nicht, siehst du genau, welches Wort, und dein Satz bleibt
    stehen, damit du nur das eine Wort ändern musst. Ein Fehler färbt
-   immer nur ein Wort, auch wenn er am Anfang des Satzes steht.
+   immer nur ein Wort, auch wenn er am Anfang des Satzes steht. Fehlt
+   ein Satzzeichen, ist das Wort davor grün und ein roter Punkt zeigt,
+   wo das Zeichen hingehört.
 7. Nach der Antwort erscheint die Regel. Vorher wäre sie nur eine
    Tabelle zum Abschreiben.
 8. Für jede Runde gibt es XP, Levels (vom Schreiblehrling zur

--- a/wortwerkstatt/css/styles.css
+++ b/wortwerkstatt/css/styles.css
@@ -6,14 +6,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=6") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=7") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=6") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=7") format("woff2");
 }
 
 :root {
@@ -982,6 +982,22 @@ h1, h2, h3 {
 
 /* A word the child left out: the gap is shown where it belongs rather
    than shifting every later word out of place. */
+/* A word and the mark after it sit together, so the sentence still
+   reads as a sentence while each is judged on its own. */
+.word-group {
+  display: inline-flex;
+  gap: 2px;
+}
+
+/* A mark is one character wide, so its cell does not need a word's
+   worth of room. */
+.word.punct {
+  min-width: 1.5rem;
+  padding-left: var(--space-1);
+  padding-right: var(--space-1);
+  text-align: center;
+}
+
 .word.gap::before {
   content: "·";
   color: var(--color-danger);

--- a/wortwerkstatt/index.html
+++ b/wortwerkstatt/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Wortwerkstatt: Rechtschreibung üben nach Lehrplan 21, Regel für Regel.">
   <title>Wortwerkstatt</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=6">
+  <link rel="stylesheet" href="css/styles.css?v=7">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Wortwerkstatt braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=6"></script>
+  <script type="module" src="js/app.js?v=7"></script>
 </body>
 </html>

--- a/wortwerkstatt/js/app.js
+++ b/wortwerkstatt/js/app.js
@@ -1,17 +1,17 @@
 // app.js — controller: owns the state, handles all interactions via
 // event delegation, persists through storage.js and renders via ui.js.
 
-import { render } from "./ui.js?v=6";
+import { render } from "./ui.js?v=7";
 import {
   topicById, chapterById, chaptersForCycle, topicKey, textById, textKey
-} from "./data.js?v=6";
-import { t, setLanguage } from "./i18n.js?v=6";
-import * as storage from "./storage.js?v=6";
+} from "./data.js?v=7";
+import { t, setLanguage } from "./i18n.js?v=7";
+import * as storage from "./storage.js?v=7";
 import {
   buildRound, buildTextRound, isCorrect, needsStudyStep, expectedAnswer,
   isTyped, needsConfirm, looksComplete, normaliseTyped
-} from "./round.js?v=6";
-import { award, xpForRound } from "./game.js?v=6";
+} from "./round.js?v=7";
+import { award, xpForRound } from "./game.js?v=7";
 
 // Consecutive clean rounds before the app offers the next cycle. The
 // offer is a suggestion, never a forced step (GAMIFICATION.md).

--- a/wortwerkstatt/js/data.js
+++ b/wortwerkstatt/js/data.js
@@ -2,7 +2,7 @@
 // three Lehrplan 21 cycles. No copy lives here; everything visible
 // resolves through the string tables in js/i18n/.
 
-import { de as contentDe } from "./content/de.js?v=6";
+import { de as contentDe } from "./content/de.js?v=7";
 
 export const LANGUAGES = [
   { code: "de", htmlLang: "de-CH", label: "Deutsch" },

--- a/wortwerkstatt/js/game.js
+++ b/wortwerkstatt/js/game.js
@@ -5,7 +5,7 @@
 // never matters. Medal checks are pure functions of the data object so
 // they can never drift from the stored state.
 
-import { topicsForCycle, contentByCode } from "./data.js?v=6";
+import { topicsForCycle, contentByCode } from "./data.js?v=7";
 
 // Cumulative XP thresholds. Beyond the last level XP keeps counting.
 export const LEVELS = [

--- a/wortwerkstatt/js/i18n.js
+++ b/wortwerkstatt/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=6";
-import { de } from "./i18n/de.js?v=6";
-import { en } from "./i18n/en.js?v=6";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=7";
+import { de } from "./i18n/de.js?v=7";
+import { en } from "./i18n/en.js?v=7";
 
 export const TABLES = { de, en };
 

--- a/wortwerkstatt/js/round.js
+++ b/wortwerkstatt/js/round.js
@@ -4,7 +4,7 @@
 // module directly to derive the expected answers, so the tests can
 // never drift from the engine.
 
-import { shuffle } from "./util.js?v=6";
+import { shuffle } from "./util.js?v=7";
 
 export const ROUND_SIZE = 6;
 
@@ -69,22 +69,29 @@ export function looksComplete(expected, typed) {
 // Which of the child's words are right, and how many are missing.
 // Returns { rows, missing }.
 //
+// A **punctuation mark is judged on its own**, not as part of the word
+// it hangs off. Writing "leicht" for "leicht." spells the word
+// perfectly and forgets the full stop; marking the word red would say
+// the child got the word wrong and hide which of the two rules they
+// actually missed. End marks and commas are their own lesson here, so
+// they are their own token.
+//
 // The two sentences are aligned rather than walked position by
 // position: position by position, one word dropped in the middle
 // shifts everything after it and the rest of the sentence turns red.
 //
-// Between two words that match, the child's unmatched words are paired
-// against the expected ones that went with them — those are words
-// written differently, not words lost and words gained, so each shows
-// as one mark carrying what the child actually wrote.
+// Between two tokens that match, the child's unmatched tokens are
+// paired against the expected ones that went with them — those are
+// words written differently, not words lost and words gained, so each
+// shows as one mark carrying what the child actually wrote.
 //
 // A gap is only ever drawn where it is genuinely known: a stretch with
-// words expected and nothing written in their place. Where words were
+// tokens expected and nothing written in their place. Where tokens were
 // replaced as well, the position of the missing one is a guess, so it
 // is counted and said in words instead of drawn in the wrong spot.
 export function wordDiff(expected, typed) {
-  const want = splitWords(expected);
-  const got = splitWords(typed);
+  const want = splitTokens(expected);
+  const got = splitTokens(typed);
   const n = want.length;
   const m = got.length;
 
@@ -92,7 +99,7 @@ export function wordDiff(expected, typed) {
   const lcs = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
   for (let i = n - 1; i >= 0; i--) {
     for (let j = m - 1; j >= 0; j--) {
-      lcs[i][j] = want[i] === got[j]
+      lcs[i][j] = want[i].text === got[j].text
         ? lcs[i + 1][j + 1] + 1
         : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
     }
@@ -104,11 +111,13 @@ export function wordDiff(expected, typed) {
   let added = [];
 
   const flush = () => {
-    for (const word of added) rows.push({ word, ok: false });
+    for (const token of added) rows.push({ word: token.text, ok: false, punct: token.punct });
     const short = dropped.length - added.length;
     if (short > 0) {
       if (added.length === 0) {
-        for (let k = 0; k < short; k++) rows.push({ word: "", ok: false, gap: true });
+        for (const token of dropped) {
+          rows.push({ word: "", ok: false, gap: true, punct: token.punct });
+        }
       } else {
         missing += short;
       }
@@ -120,10 +129,11 @@ export function wordDiff(expected, typed) {
   let i = 0;
   let j = 0;
   while (i < n && j < m) {
-    if (want[i] === got[j]) {
+    if (want[i].text === got[j].text) {
       flush();
-      rows.push({ word: got[j++], ok: true });
+      rows.push({ word: got[j].text, ok: true, punct: got[j].punct });
       i += 1;
+      j += 1;
     } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
       dropped.push(want[i++]);
     } else {
@@ -135,6 +145,21 @@ export function wordDiff(expected, typed) {
   flush();
 
   return { rows, missing };
+}
+
+// A word and the mark that follows it are two things to get right, so
+// they are two tokens: "leicht." becomes "leicht" and ".".
+function splitTokens(value) {
+  const tokens = [];
+  for (const chunk of splitWords(value)) {
+    const match = /^(.*?)([.,!?;:]+)$/.exec(chunk);
+    if (!match) tokens.push({ text: chunk, punct: false });
+    else {
+      if (match[1]) tokens.push({ text: match[1], punct: false });
+      tokens.push({ text: match[2], punct: true });
+    }
+  }
+  return tokens;
 }
 
 function splitWords(value) {

--- a/wortwerkstatt/js/storage.js
+++ b/wortwerkstatt/js/storage.js
@@ -4,7 +4,7 @@
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   DEFAULT_LANGUAGE, DEFAULT_CONTENT_LANGUAGE, DEFAULT_CYCLE
-} from "./data.js?v=6";
+} from "./data.js?v=7";
 
 const KEY = "wortwerkstatt.state";
 

--- a/wortwerkstatt/js/ui.js
+++ b/wortwerkstatt/js/ui.js
@@ -4,18 +4,18 @@
 // i18n; every practice string comes from the content pack and is
 // marked with the content language so screen readers switch voice.
 
-import { icon } from "./icons.js?v=6";
+import { icon } from "./icons.js?v=7";
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   contentByCode, topicsForCycle, topicById, topicKey,
   textsForCycle, textById, textKey, LEHRPLAN_VERSION
-} from "./data.js?v=6";
-import { t, currentLanguage } from "./i18n.js?v=6";
-import { escapeHtml, statusOf, topicStatus } from "./util.js?v=6";
+} from "./data.js?v=7";
+import { t, currentLanguage } from "./i18n.js?v=7";
+import { escapeHtml, statusOf, topicStatus } from "./util.js?v=7";
 import {
   fillTask, expectedAnswer, letterDiff, wordDiff, isTyped, needsConfirm, ROUND_SIZE
-} from "./round.js?v=6";
-import { MEDALS, levelFor } from "./game.js?v=6";
+} from "./round.js?v=7";
+import { MEDALS, levelFor } from "./game.js?v=7";
 
 // Sentinel put in place of the answer so the blank lands exactly where
 // round.js says it does, spacing included. A control character, because
@@ -592,9 +592,18 @@ function typedBack(state, task, answer, typed) {
 
 function typedWords(state, answer, typed) {
   const { rows, missing } = wordDiff(answer, typed);
-  const cells = rows.map(({ word, ok, gap }) =>
-    `<span class="word ${ok ? "ok" : "miss"}${gap ? " gap" : ""}">${escapeHtml(word)}</span>`).join("");
-  // Where the missing word's position is a guess, it is said in words
+  // A mark belongs against the word it follows, so the sentence still
+  // reads as a sentence even though the two are judged separately.
+  const groups = [];
+  for (const row of rows) {
+    if (row.punct && groups.length) groups[groups.length - 1].push(row);
+    else groups.push([row]);
+  }
+  const cell = ({ word, ok, gap, punct }) =>
+    `<span class="word ${ok ? "ok" : "miss"}${gap ? " gap" : ""}${punct ? " punct" : ""}">${escapeHtml(word)}</span>`;
+  const cells = groups
+    .map((group) => `<span class="word-group">${group.map(cell).join("")}</span>`).join("");
+  // Where a missing token's position is a guess, it is said in words
   // rather than drawn somewhere it probably does not belong.
   const shortfall = missing === 0 ? ""
     : `<p class="hint">${missing === 1 ? t("wordsMissingOne") : t("wordsMissingMany", { n: missing })}</p>`;

--- a/wortwerkstatt/tests/e2e.test.mjs
+++ b/wortwerkstatt/tests/e2e.test.mjs
@@ -22,13 +22,13 @@ import { fileURLToPath } from "node:url";
 import {
   CONTENT_LANGUAGES, CYCLES, topicsForCycle, topicKey,
   textsForCycle, textKey, LEHRPLAN_VERSION
-} from "../js/data.js?v=6";
-import { TABLES } from "../js/i18n.js?v=6";
+} from "../js/data.js?v=7";
+import { TABLES } from "../js/i18n.js?v=7";
 import {
   fillTask, expectedAnswer, solutionText, isTyped, needsConfirm, wordDiff,
   looksComplete, ROUND_SIZE
-} from "../js/round.js?v=6";
-import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=6";
+} from "../js/round.js?v=7";
+import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=7";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -266,11 +266,14 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   for (const item of CONTENT.texts.flatMap((text) => text.sentences)) {
     const words = item.answer.split(" ");
     if (words.length < 4) continue;
+    // Drop a word that carries no mark of its own: deleting "wusste,"
+    // would remove a word and a comma, which is two slips, not one.
+    const plain = words.findIndex((w, k) => k > 0 && k < words.length - 1 && !/[.,!?;:]$/.test(w));
     const cases = [
       ["a small first letter", words.map((w, k) => (k ? w : w.toLowerCase())).join(" ")],
-      ["a word left out", words.filter((_, k) => k !== 1).join(" ")],
       ["a word too many", [...words.slice(0, 2), "sehr", ...words.slice(2)].join(" ")]
     ];
+    if (plain > 0) cases.push(["a word left out", words.filter((_, k) => k !== plain).join(" ")]);
     for (const [name, typed] of cases) {
       const { rows, missing } = wordDiff(item.answer, typed);
       const red = rows.filter((w) => !w.ok).length + missing;
@@ -293,11 +296,24 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
     check("replaced words never draw a gap where nothing is missing", gaps === 0, `${gaps} gaps`);
     check("the word that is genuinely missing is counted instead", missing === 1, String(missing));
     check("the marks carry back what the child actually wrote",
-      rows.map((w) => w.word).join(" ") === "das lernen fiel im schwer.",
-      rows.map((w) => w.word).join(" "));
+      rows.filter((w) => !w.ok && !w.gap).map((w) => w.word).join(" ") === "das lernen im schwer",
+      rows.filter((w) => !w.ok && !w.gap).map((w) => w.word).join(" "));
     const pure = wordDiff(answer, "Das Lernen fiel ihm leicht.");
     check("a word left out with nothing in its place still shows a gap",
       pure.rows.filter((w) => w.gap).length === 1 && pure.missing === 0);
+
+    // A mark is its own lesson, so it is judged on its own: forgetting
+    // the full stop must not call the word in front of it misspelled.
+    const noStop = wordDiff(answer, "Das Lernen fiel ihm diesmal leicht");
+    check("a missing end mark leaves the word before it right",
+      noStop.rows.every((w) => w.ok || w.gap) && noStop.rows.filter((w) => w.gap).length === 1,
+      noStop.rows.map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" "));
+    check("the gap left by a mark is marked as a mark",
+      noStop.rows.find((w) => w.gap).punct === true);
+    const noComma = wordDiff("Er wusste, dass es regnet.", "Er wusste dass es regnet.");
+    check("a missing comma leaves the word before it right",
+      noComma.rows.every((w) => w.ok || w.gap) && noComma.rows.filter((w) => w.gap).length === 1,
+      noComma.rows.map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" "));
   }
   const perCycle = CYCLES.map((c) => textsForCycle(CONTENT.code, c).length);
   check("every cycle has texts to write", perCycle.every((n) => n > 0), perCycle.join("/"));


### PR DESCRIPTION
Fixes a reported mis-marking: writing `das Lernen fiel ihm dismal leicht` marked **`leicht` red**. The word is spelled perfectly — the missing thing is the full stop.

**Live once merged:** https://lfdave.github.io/small-apps/wortwerkstatt/index.html?r=20260803-7

## The modelling flaw

Marks were glued to the word in front of them, so `leicht` and `leicht.` compared as different *words*. Forgetting a full stop therefore looked like misspelling the word — and hid which of the two rules the child actually missed. In an app where Satzschlusszeichen and Kommasetzung are their own named rules, that's the wrong model.

A mark is now its own token: `leicht.` splits into `leicht` and `.`, each judged separately.

| Typed | Before | Now |
|---|---|---|
| `das Lernen fiel ihm dismal leicht` | `[das]` Lernen fiel ihm `[dismal]` **`[leicht]`** | `[das]` Lernen fiel ihm `[dismal]` leicht **`[·]`** |
| `Er wusste dass es regnet.` (no comma) | Er **`[wusste]`** dass es regnet . | Er wusste **`[·]`** dass es regnet . |

The comma case improves the same way — `wusste` stays green and the gap sits where the comma belongs, rather than the word being called wrong.

Marks render in a narrow cell grouped tight against their word, so the sentence still reads as a sentence while the two are judged apart.

## Testing

**193 checks pass.** New: a missing end mark and a missing comma must each leave every other token right and produce exactly one gap, and that gap must be flagged as a mark rather than a word.

One existing check needed correcting rather than the code: the one-slip-one-mark sweep deleted `words[1]`, which for several sentences is `wusste,` — a word *and* its comma. Two marks was the right answer; the test was asking the wrong question. It now drops a word that carries no mark of its own.

## Docs

`PRD.md`, `CLAUDE.md` and `README.md`, each verified present after editing rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1)_