### PR TITLE
Pair words by similarity, so the dots land where words are missing

### DIFF
--- a/wortwerkstatt/CLAUDE.md
+++ b/wortwerkstatt/CLAUDE.md
@@ -126,12 +126,13 @@ All enforced by the e2e suite unless noted:
   marks the mark and leaves the word before it green. End marks and
   commas are their own rules here — never fold them back into the word.
   Marks render in a narrow cell grouped tight against their word so the
-  sentence still reads as one. A **gap cell is only ever drawn
-  where nothing was written in its place**; where words were replaced
-  too, the missing word's position is a guess, so it goes into `missing`
-  and is said in words. Do not draw gaps straight from the raw
-  alignment — the dots land where nothing is missing and the marking
-  reads as noise.
+  sentence still reads as one. The alignment pairs on **`sameWord`**,
+  not on position: same letters in another case, or within an edit or
+  two, and a mark never pairs with a word. **Never pair by position** —
+  it matches "fil" to "Lernen" and the dots for the words actually left
+  out land nowhere near them. Every expected token with nothing standing
+  in for it is drawn as a dot in its own place; `missing` counts only
+  the word gaps, since a missing mark speaks through its own dot.
   In the writing mode the sentence in hand is named in the instruction
   and pointed at with a chevron — without that a child writes the wrong
   line of the paragraph and every word comes back wrong. The advisory line under

--- a/wortwerkstatt/PRD.md
+++ b/wortwerkstatt/PRD.md
@@ -287,13 +287,23 @@ against the expected ones that went with them: those are words written
 differently, not words lost and words gained, so each shows as one mark
 carrying **what the child actually wrote**.
 
-**A gap is only drawn where it is genuinely known** — a stretch with
-words expected and nothing written in their place. Where words were
-replaced as well, the position of a missing word is a guess, so it is
-counted and said in words ("Ein Wort fehlt noch.") instead of drawn
-somewhere it probably does not belong. Dots scattered through a
-sentence that also has replacements point at spots where nothing is
-missing, which reads as noise.
+**The alignment pairs tokens that are the same word written
+differently** — the same letters in another case, or within an edit or
+two (`sameWord`). That is what decides where a gap belongs. Pairing by
+position instead matches `fil` to `Lernen` and `im` to `fiel`, and then
+the dots for the words genuinely left out land nowhere near them.
+
+Every expected token with nothing standing in for it is drawn as a
+**dot in its own place**, so a child sees where a word or a mark is
+missing rather than being told a number. A mark never pairs with a
+word, so a missing full stop is a dot after the word, not a word marked
+wrong. The count under the cells names how many *words* are missing;
+marks speak for themselves through their dot.
+
+The trade-off is deliberate: a child who writes a wholly different word
+(`schwer` for `leicht`) gets the expected word shown as missing **and**
+their own word marked, rather than the two being paired on a guess. That
+is one mark more, and it is the honest account.
 
 The suite holds this to one mark per slip: for every sentence in the
 pack, a small first letter, a word left out and a word too many must

--- a/wortwerkstatt/README.md
+++ b/wortwerkstatt/README.md
@@ -32,8 +32,8 @@ stehen darum auf beiden Listen.
    etwas nicht, siehst du genau, welches Wort, und dein Satz bleibt
    stehen, damit du nur das eine Wort ändern musst. Ein Fehler färbt
    immer nur ein Wort, auch wenn er am Anfang des Satzes steht. Fehlt
-   ein Satzzeichen, ist das Wort davor grün und ein roter Punkt zeigt,
-   wo das Zeichen hingehört.
+   ein Satzzeichen oder ein ganzes Wort, steht ein roter Punkt genau
+   dort, wo es hingehört.
 7. Nach der Antwort erscheint die Regel. Vorher wäre sie nur eine
    Tabelle zum Abschreiben.
 8. Für jede Runde gibt es XP, Levels (vom Schreiblehrling zur

--- a/wortwerkstatt/css/styles.css
+++ b/wortwerkstatt/css/styles.css
@@ -6,14 +6,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=7") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=8") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=7") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=8") format("woff2");
 }
 
 :root {

--- a/wortwerkstatt/index.html
+++ b/wortwerkstatt/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Wortwerkstatt: Rechtschreibung üben nach Lehrplan 21, Regel für Regel.">
   <title>Wortwerkstatt</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=7">
+  <link rel="stylesheet" href="css/styles.css?v=8">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Wortwerkstatt braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=7"></script>
+  <script type="module" src="js/app.js?v=8"></script>
 </body>
 </html>

--- a/wortwerkstatt/js/app.js
+++ b/wortwerkstatt/js/app.js
@@ -1,17 +1,17 @@
 // app.js — controller: owns the state, handles all interactions via
 // event delegation, persists through storage.js and renders via ui.js.
 
-import { render } from "./ui.js?v=7";
+import { render } from "./ui.js?v=8";
 import {
   topicById, chapterById, chaptersForCycle, topicKey, textById, textKey
-} from "./data.js?v=7";
-import { t, setLanguage } from "./i18n.js?v=7";
-import * as storage from "./storage.js?v=7";
+} from "./data.js?v=8";
+import { t, setLanguage } from "./i18n.js?v=8";
+import * as storage from "./storage.js?v=8";
 import {
   buildRound, buildTextRound, isCorrect, needsStudyStep, expectedAnswer,
   isTyped, needsConfirm, looksComplete, normaliseTyped
-} from "./round.js?v=7";
-import { award, xpForRound } from "./game.js?v=7";
+} from "./round.js?v=8";
+import { award, xpForRound } from "./game.js?v=8";
 
 // Consecutive clean rounds before the app offers the next cycle. The
 // offer is a suggestion, never a forced step (GAMIFICATION.md).

--- a/wortwerkstatt/js/data.js
+++ b/wortwerkstatt/js/data.js
@@ -2,7 +2,7 @@
 // three Lehrplan 21 cycles. No copy lives here; everything visible
 // resolves through the string tables in js/i18n/.
 
-import { de as contentDe } from "./content/de.js?v=7";
+import { de as contentDe } from "./content/de.js?v=8";
 
 export const LANGUAGES = [
   { code: "de", htmlLang: "de-CH", label: "Deutsch" },

--- a/wortwerkstatt/js/game.js
+++ b/wortwerkstatt/js/game.js
@@ -5,7 +5,7 @@
 // never matters. Medal checks are pure functions of the data object so
 // they can never drift from the stored state.
 
-import { topicsForCycle, contentByCode } from "./data.js?v=7";
+import { topicsForCycle, contentByCode } from "./data.js?v=8";
 
 // Cumulative XP thresholds. Beyond the last level XP keeps counting.
 export const LEVELS = [

--- a/wortwerkstatt/js/i18n.js
+++ b/wortwerkstatt/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=7";
-import { de } from "./i18n/de.js?v=7";
-import { en } from "./i18n/en.js?v=7";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=8";
+import { de } from "./i18n/de.js?v=8";
+import { en } from "./i18n/en.js?v=8";
 
 export const TABLES = { de, en };
 

--- a/wortwerkstatt/js/round.js
+++ b/wortwerkstatt/js/round.js
@@ -4,7 +4,7 @@
 // module directly to derive the expected answers, so the tests can
 // never drift from the engine.
 
-import { shuffle } from "./util.js?v=7";
+import { shuffle } from "./util.js?v=8";
 
 export const ROUND_SIZE = 6;
 
@@ -73,78 +73,84 @@ export function looksComplete(expected, typed) {
 // it hangs off. Writing "leicht" for "leicht." spells the word
 // perfectly and forgets the full stop; marking the word red would say
 // the child got the word wrong and hide which of the two rules they
-// actually missed. End marks and commas are their own lesson here, so
-// they are their own token.
+// actually missed.
 //
-// The two sentences are aligned rather than walked position by
-// position: position by position, one word dropped in the middle
-// shifts everything after it and the rest of the sentence turns red.
+// The two sentences are **aligned**, not walked position by position:
+// position by position, one word dropped in the middle shifts
+// everything after it and the rest of the sentence turns red.
 //
-// Between two tokens that match, the child's unmatched tokens are
-// paired against the expected ones that went with them — those are
-// words written differently, not words lost and words gained, so each
-// shows as one mark carrying what the child actually wrote.
-//
-// A gap is only ever drawn where it is genuinely known: a stretch with
-// tokens expected and nothing written in their place. Where tokens were
-// replaced as well, the position of the missing one is a guess, so it
-// is counted and said in words instead of drawn in the wrong spot.
+// The alignment pairs tokens that are the **same word written
+// differently** — the same letters in another case, or within an edit
+// or two. That is what decides where a gap belongs. Pairing by position
+// instead would match "fil" to "Lernen" and "im" to "fiel", and the
+// dots for the words genuinely left out would land nowhere near them.
 export function wordDiff(expected, typed) {
-  const want = splitTokens(expected);
-  const got = splitTokens(typed);
+  const rows = [];
+  let missing = 0;
+
+  for (const op of align(splitTokens(expected), splitTokens(typed))) {
+    if (op.type === "drop") {
+      // Nothing was written here, so the gap is shown where it belongs.
+      rows.push({ word: "", ok: false, gap: true, punct: op.want.punct });
+      if (!op.want.punct) missing += 1;
+    } else {
+      const ok = op.type === "pair" && op.want.text === op.got.text;
+      rows.push({ word: op.got.text, ok, punct: op.got.punct });
+    }
+  }
+  return { rows, missing };
+}
+
+// Order-preserving alignment of two token lists over `sameWord`.
+function align(want, got) {
   const n = want.length;
   const m = got.length;
-
-  // Longest common subsequence over the suffixes of both sentences.
   const lcs = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
   for (let i = n - 1; i >= 0; i--) {
     for (let j = m - 1; j >= 0; j--) {
-      lcs[i][j] = want[i].text === got[j].text
+      lcs[i][j] = sameWord(want[i], got[j])
         ? lcs[i + 1][j + 1] + 1
         : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
     }
   }
-
-  const rows = [];
-  let missing = 0;
-  let dropped = [];
-  let added = [];
-
-  const flush = () => {
-    for (const token of added) rows.push({ word: token.text, ok: false, punct: token.punct });
-    const short = dropped.length - added.length;
-    if (short > 0) {
-      if (added.length === 0) {
-        for (const token of dropped) {
-          rows.push({ word: "", ok: false, gap: true, punct: token.punct });
-        }
-      } else {
-        missing += short;
-      }
-    }
-    dropped = [];
-    added = [];
-  };
-
+  const ops = [];
   let i = 0;
   let j = 0;
   while (i < n && j < m) {
-    if (want[i].text === got[j].text) {
-      flush();
-      rows.push({ word: got[j].text, ok: true, punct: got[j].punct });
-      i += 1;
-      j += 1;
-    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
-      dropped.push(want[i++]);
-    } else {
-      added.push(got[j++]);
-    }
+    if (sameWord(want[i], got[j])) ops.push({ type: "pair", want: want[i++], got: got[j++] });
+    else if (lcs[i + 1][j] >= lcs[i][j + 1]) ops.push({ type: "drop", want: want[i++] });
+    else ops.push({ type: "add", got: got[j++] });
   }
-  while (j < m) added.push(got[j++]);
-  while (i < n) dropped.push(want[i++]);
-  flush();
+  while (j < m) ops.push({ type: "add", got: got[j++] });
+  while (i < n) ops.push({ type: "drop", want: want[i++] });
+  return ops;
+}
 
-  return { rows, missing };
+// Whether two tokens are one word the child was reaching for: the same
+// letters in another case, or close enough that "fil" is plainly an
+// attempt at "fiel". A mark never pairs with a word.
+function sameWord(a, b) {
+  if (a.punct !== b.punct) return false;
+  const x = a.text.toLowerCase();
+  const y = b.text.toLowerCase();
+  if (x === y) return true;
+  const longest = Math.max(x.length, y.length);
+  if (longest <= 2) return false;
+  return editDistance(x, y) <= (longest <= 5 ? 1 : 2);
+}
+
+function editDistance(a, b) {
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i];
+    for (let j = 1; j <= b.length; j++) {
+      row[j] = a[i - 1] === b[j - 1]
+        ? prev[j - 1]
+        : 1 + Math.min(prev[j - 1], prev[j], row[j - 1]);
+    }
+    prev = row;
+  }
+  return prev[b.length];
 }
 
 // A word and the mark that follows it are two things to get right, so

--- a/wortwerkstatt/js/storage.js
+++ b/wortwerkstatt/js/storage.js
@@ -4,7 +4,7 @@
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   DEFAULT_LANGUAGE, DEFAULT_CONTENT_LANGUAGE, DEFAULT_CYCLE
-} from "./data.js?v=7";
+} from "./data.js?v=8";
 
 const KEY = "wortwerkstatt.state";
 

--- a/wortwerkstatt/js/ui.js
+++ b/wortwerkstatt/js/ui.js
@@ -4,18 +4,18 @@
 // i18n; every practice string comes from the content pack and is
 // marked with the content language so screen readers switch voice.
 
-import { icon } from "./icons.js?v=7";
+import { icon } from "./icons.js?v=8";
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   contentByCode, topicsForCycle, topicById, topicKey,
   textsForCycle, textById, textKey, LEHRPLAN_VERSION
-} from "./data.js?v=7";
-import { t, currentLanguage } from "./i18n.js?v=7";
-import { escapeHtml, statusOf, topicStatus } from "./util.js?v=7";
+} from "./data.js?v=8";
+import { t, currentLanguage } from "./i18n.js?v=8";
+import { escapeHtml, statusOf, topicStatus } from "./util.js?v=8";
 import {
   fillTask, expectedAnswer, letterDiff, wordDiff, isTyped, needsConfirm, ROUND_SIZE
-} from "./round.js?v=7";
-import { MEDALS, levelFor } from "./game.js?v=7";
+} from "./round.js?v=8";
+import { MEDALS, levelFor } from "./game.js?v=8";
 
 // Sentinel put in place of the answer so the blank lands exactly where
 // round.js says it does, spacing included. A control character, because

--- a/wortwerkstatt/tests/e2e.test.mjs
+++ b/wortwerkstatt/tests/e2e.test.mjs
@@ -22,13 +22,13 @@ import { fileURLToPath } from "node:url";
 import {
   CONTENT_LANGUAGES, CYCLES, topicsForCycle, topicKey,
   textsForCycle, textKey, LEHRPLAN_VERSION
-} from "../js/data.js?v=7";
-import { TABLES } from "../js/i18n.js?v=7";
+} from "../js/data.js?v=8";
+import { TABLES } from "../js/i18n.js?v=8";
 import {
   fillTask, expectedAnswer, solutionText, isTyped, needsConfirm, wordDiff,
   looksComplete, ROUND_SIZE
-} from "../js/round.js?v=7";
-import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=7";
+} from "../js/round.js?v=8";
+import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=8";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -275,8 +275,9 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
     ];
     if (plain > 0) cases.push(["a word left out", words.filter((_, k) => k !== plain).join(" ")]);
     for (const [name, typed] of cases) {
-      const { rows, missing } = wordDiff(item.answer, typed);
-      const red = rows.filter((w) => !w.ok).length + missing;
+      // Every mark is a row: a word shown wrong, or a gap where one
+      // belongs. `missing` counts a subset of those, so it is not added.
+      const red = wordDiff(item.answer, typed).rows.filter((w) => !w.ok).length;
       if (red !== 1) markProblems.push(`${item.answer} with ${name}: ${red} marked`);
     }
     if (wordDiff(item.answer, item.answer).rows.some((w) => !w.ok)) {
@@ -291,29 +292,37 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   // written in its place, or the dots land where no word is missing.
   {
     const answer = "Das Lernen fiel ihm diesmal leicht.";
-    const { rows, missing } = wordDiff(answer, "das lernen fiel im schwer.");
-    const gaps = rows.filter((w) => w.gap).length;
-    check("replaced words never draw a gap where nothing is missing", gaps === 0, `${gaps} gaps`);
-    check("the word that is genuinely missing is counted instead", missing === 1, String(missing));
-    check("the marks carry back what the child actually wrote",
-      rows.filter((w) => !w.ok && !w.gap).map((w) => w.word).join(" ") === "das lernen im schwer",
-      rows.filter((w) => !w.ok && !w.gap).map((w) => w.word).join(" "));
-    const pure = wordDiff(answer, "Das Lernen fiel ihm leicht.");
-    check("a word left out with nothing in its place still shows a gap",
-      pure.rows.filter((w) => w.gap).length === 1 && pure.missing === 0);
+    const shape = (typed) => wordDiff(answer, typed).rows
+      .map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" ");
 
-    // A mark is its own lesson, so it is judged on its own: forgetting
-    // the full stop must not call the word in front of it misspelled.
-    const noStop = wordDiff(answer, "Das Lernen fiel ihm diesmal leicht");
+    // Reported: "fil" is an attempt at "fiel" and "im" at "ihm", so the
+    // words with nothing standing in for them are "Lernen" and
+    // "diesmal" — and that is exactly where the dots belong. Pairing by
+    // position instead would match "fil" to "Lernen" and scatter them.
+    check("dots land where the missing words belong",
+      shape("das fil im leicht") === "[das] [\u00b7] [fil] [im] [\u00b7] leicht [\u00b7]",
+      shape("das fil im leicht"));
+    check("the missing words are counted as words, the mark apart",
+      wordDiff(answer, "das fil im leicht").missing === 2);
+
+    // A word left out with nothing in its place: one dot, in place.
+    check("a word left out shows one dot where it belongs",
+      shape("Das Lernen fiel ihm leicht.") === "Das Lernen fiel ihm [\u00b7] leicht .",
+      shape("Das Lernen fiel ihm leicht."));
+
+    // A mark is its own lesson: forgetting the full stop must not call
+    // the word in front of it misspelled.
     check("a missing end mark leaves the word before it right",
-      noStop.rows.every((w) => w.ok || w.gap) && noStop.rows.filter((w) => w.gap).length === 1,
-      noStop.rows.map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" "));
-    check("the gap left by a mark is marked as a mark",
-      noStop.rows.find((w) => w.gap).punct === true);
-    const noComma = wordDiff("Er wusste, dass es regnet.", "Er wusste dass es regnet.");
+      shape("Das Lernen fiel ihm diesmal leicht") === "Das Lernen fiel ihm diesmal leicht [\u00b7]",
+      shape("Das Lernen fiel ihm diesmal leicht"));
+    const noStop = wordDiff(answer, "Das Lernen fiel ihm diesmal leicht");
+    check("a missing mark is marked as a mark, never counted as a word",
+      noStop.rows.find((w) => w.gap).punct === true && noStop.missing === 0);
+
+    const commaShape = wordDiff("Er wusste, dass es regnet.", "Er wusste dass es regnet.").rows
+      .map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" ");
     check("a missing comma leaves the word before it right",
-      noComma.rows.every((w) => w.ok || w.gap) && noComma.rows.filter((w) => w.gap).length === 1,
-      noComma.rows.map((w) => (w.ok ? w.word : "[" + (w.word || "\u00b7") + "]")).join(" "));
+      commaShape === "Er wusste [\u00b7] dass es regnet .", commaShape);
   }
   const perCycle = CYCLES.map((c) => textsForCycle(CONTENT.code, c).length);
   check("every cycle has texts to write", perCycle.every((n) => n > 0), perCycle.join("/"));


### PR DESCRIPTION
Fixes a reported gap in the feedback: writing `das fil im leicht` for `Das Lernen fiel ihm diesmal leicht.` marked three words and said *"2 Wörter fehlen noch."* — without showing **where**.

**Live once merged:** https://lfdave.github.io/small-apps/wortwerkstatt/index.html?r=20260803-8

## The cause

Inside a run of differences, the child's words were paired to the expected ones **by position**. So `fil` was taken as an attempt at `Lernen`, and `im` as one at `fiel`. With the pairing wrong, the words genuinely left out couldn't be placed — which is exactly why the previous change wrote the count out in words instead of drawing it.

## The fix

Pairing now asks whether two tokens are **the same word written differently**: same letters in another case, or within an edit or two (`sameWord`), and a mark never pairs with a word. That puts `fil` against `fiel` and `im` against `ihm`, leaving `Lernen` and `diesmal` with nothing standing in for them:

| Typed | Before | Now |
|---|---|---|
| `das fil im leicht` | `[das] [fil] [im]` leicht `[·]` + *"2 fehlen"* | `[das]` **`[·]`** `[fil] [im]` **`[·]`** leicht `[·]` |
| `Das Lernen fiel ihm leicht.` | dot in place | dot in place, unchanged |
| `Er wusste dass es regnet.` | `wusste` green, dot for the comma | unchanged |

Every expected token with nothing in its place is now a **dot in its own place** rather than a number. The count under the cells names only the missing *words*, since a missing mark speaks through its own dot.

## A trade-off worth naming

Writing a wholly different word — `schwer` for `leicht` — now shows the expected word as missing **and** the written one as wrong, instead of pairing the two on a guess. That's one mark more than before for that case. I chose the honest account over the tidier one, and it's documented in the PRD rather than left as a surprise.

## Testing

**192 checks pass.** The reported input is pinned as an exact rendered shape: `[das] [·] [fil] [im] [·] leicht [·]`.

Two existing checks needed **rewriting rather than fixing**, which is worth being explicit about:

- One counted marks as `rows.filter(!ok).length + missing` — that double-counts now that a gap is both a row and part of `missing`.
- Two pinned the *previous* decision (gaps only where provably known, otherwise counted). This change deliberately reverses it, so those assertions encoded intent that no longer holds. They now pin the new intent instead.

## Docs

`PRD.md`, `CLAUDE.md` and `README.md` — each verified present after editing, and the superseded claims verified gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1)_