### PR TITLE
Stop judging a sentence while it is being corrected

### DIFF
--- a/wortwerkstatt/CLAUDE.md
+++ b/wortwerkstatt/CLAUDE.md
@@ -110,7 +110,13 @@ All enforced by the e2e suite unless noted:
   short never reaches the expected length and hangs forever with no
   feedback — the bug this rule exists to prevent. **Never widen
   `looksComplete` to a state a half-typed sentence can reach**; the
-  suite feeds every prefix of every answer through it. Confirmed fields
+  suite feeds every prefix of every answer through it. `round.editing`
+  turns the shape rule off while a retry has kept the sentence on
+  screen: a correction takes several edits, and judging after each one
+  answers "still wrong" repeatedly. Only an exactly right sentence is
+  judged then. **Keep `editing` tied to whether the field was kept** —
+  clearing it (reveal, next task) makes it fresh writing again — and
+  keep the advisory line switching with it (WCAG 3.2.2). Confirmed fields
   allow overshoot, so a too-long answer stays finishable, and
   `normaliseTyped` strips stray spacing before anything is judged. A
   retry keeps a sentence, so the child fixes the marked word instead of

--- a/wortwerkstatt/PRD.md
+++ b/wortwerkstatt/PRD.md
@@ -240,7 +240,17 @@ A sentence looks finished in exactly two cases, both in `looksComplete`:
    class: a missing comma, a small letter, one letter short in a word.
 
 Anything else waits for the button, because a sentence with too few or
-too many words cannot be told apart from one still being typed. The
+too many words cannot be told apart from one still being typed.
+
+**While correcting, only a right sentence is judged.** Once a retry has
+kept the sentence on screen, the child is editing rather than writing it
+out, and a correction often takes several edits. Judging the shape after
+each keystroke answers "still wrong" over and over before they have
+finished, so the second rule is switched off and they say when they are
+done — while a correction that lands right is still accepted at once.
+The advisory line under the field changes with it, so the behaviour is
+always announced before use (WCAG 3.2.2). Clearing the field (a reveal,
+or the next task) makes it fresh writing again. The
 suite proves the boundary by feeding every prefix of every right answer
 through `looksComplete` and requiring that none of them is judged.
 

--- a/wortwerkstatt/README.md
+++ b/wortwerkstatt/README.md
@@ -30,7 +30,10 @@ stehen darum auf beiden Listen.
    aussieht: wenn er stimmt, oder wenn er gleich viele Wörter hat und
    mit einem Satzzeichen endet. Sonst tippst du auf Fertig. Stimmt
    etwas nicht, siehst du genau, welches Wort, und dein Satz bleibt
-   stehen, damit du nur das eine Wort ändern musst. Ein Fehler färbt
+   stehen, damit du nur das eine Wort ändern musst. Beim Korrigieren
+   prüft die App nichts mehr von selbst, solange noch etwas fehlt: du
+   kannst in Ruhe mehrere Stellen ändern und tippst dann auf Fertig.
+   Stimmt alles, siehst du es sofort. Ein Fehler färbt
    immer nur ein Wort, auch wenn er am Anfang des Satzes steht. Fehlt
    ein Satzzeichen oder ein ganzes Wort, steht ein roter Punkt genau
    dort, wo es hingehört.

--- a/wortwerkstatt/css/styles.css
+++ b/wortwerkstatt/css/styles.css
@@ -6,14 +6,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=8") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=9") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=8") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=9") format("woff2");
 }
 
 :root {

--- a/wortwerkstatt/index.html
+++ b/wortwerkstatt/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Wortwerkstatt: Rechtschreibung üben nach Lehrplan 21, Regel für Regel.">
   <title>Wortwerkstatt</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=8">
+  <link rel="stylesheet" href="css/styles.css?v=9">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Wortwerkstatt braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=8"></script>
+  <script type="module" src="js/app.js?v=9"></script>
 </body>
 </html>

--- a/wortwerkstatt/js/app.js
+++ b/wortwerkstatt/js/app.js
@@ -1,17 +1,17 @@
 // app.js — controller: owns the state, handles all interactions via
 // event delegation, persists through storage.js and renders via ui.js.
 
-import { render } from "./ui.js?v=8";
+import { render } from "./ui.js?v=9";
 import {
   topicById, chapterById, chaptersForCycle, topicKey, textById, textKey
-} from "./data.js?v=8";
-import { t, setLanguage } from "./i18n.js?v=8";
-import * as storage from "./storage.js?v=8";
+} from "./data.js?v=9";
+import { t, setLanguage } from "./i18n.js?v=9";
+import * as storage from "./storage.js?v=9";
 import {
   buildRound, buildTextRound, isCorrect, needsStudyStep, expectedAnswer,
   isTyped, needsConfirm, looksComplete, normaliseTyped
-} from "./round.js?v=8";
-import { award, xpForRound } from "./game.js?v=8";
+} from "./round.js?v=9";
+import { award, xpForRound } from "./game.js?v=9";
 
 // Consecutive clean rounds before the app offers the next cycle. The
 // offer is a suggestion, never a forced step (GAMIFICATION.md).
@@ -85,6 +85,7 @@ function startRound({ entries, title, topicId, chapterId, textId, tasks: given }
     wrong: 0,
     missed: false,
     firstTry: [],
+    editing: false,
     reward: null,
     suggestCycle: null,
     nextChapterId: null,
@@ -190,6 +191,7 @@ function nextTask() {
   const r = state.round;
   r.i += 1;
   r.typed = "";
+  r.editing = false;
   r.chosen = null;
   r.wrong = 0;
   r.missed = false;
@@ -276,7 +278,10 @@ document.addEventListener("click", (e) => {
       // A sentence is expensive to retype, so a retry keeps what was
       // written and the child fixes the word that is marked. A single
       // word is three to ten characters, so it starts fresh.
-      if (!needsConfirm(r.tasks[r.i].kind)) r.typed = "";
+      // Keeping the sentence means the child is correcting it, not
+      // writing it out again, so nothing is judged until they say so.
+      r.editing = needsConfirm(r.tasks[r.i].kind);
+      if (!r.editing) r.typed = "";
       r.chosen = null;
       r.phase = "ask";
       render(state);
@@ -286,7 +291,9 @@ document.addEventListener("click", (e) => {
     case "reveal-done": {
       // The miss stays on the record for the summary; only the counter
       // that offers the reveal starts over.
+      // The field starts empty again, so this is fresh writing.
       r.typed = "";
+      r.editing = false;
       r.chosen = null;
       r.wrong = 0;
       r.phase = "ask";
@@ -328,7 +335,7 @@ document.addEventListener("input", (e) => {
   const task = r.tasks[r.i];
   if (!needsConfirm(task.kind)) {
     checkWritten();
-  } else if (looksComplete(expectedAnswer(task), value)) {
+  } else if (looksComplete(expectedAnswer(task), value, { editing: r.editing })) {
     // The sentence looks finished, so there is nothing to wait for.
     // The button stays for everything this cannot tell apart from a
     // sentence still being typed.

--- a/wortwerkstatt/js/data.js
+++ b/wortwerkstatt/js/data.js
@@ -2,7 +2,7 @@
 // three Lehrplan 21 cycles. No copy lives here; everything visible
 // resolves through the string tables in js/i18n/.
 
-import { de as contentDe } from "./content/de.js?v=8";
+import { de as contentDe } from "./content/de.js?v=9";
 
 export const LANGUAGES = [
   { code: "de", htmlLang: "de-CH", label: "Deutsch" },

--- a/wortwerkstatt/js/game.js
+++ b/wortwerkstatt/js/game.js
@@ -5,7 +5,7 @@
 // never matters. Medal checks are pure functions of the data object so
 // they can never drift from the stored state.
 
-import { topicsForCycle, contentByCode } from "./data.js?v=8";
+import { topicsForCycle, contentByCode } from "./data.js?v=9";
 
 // Cumulative XP thresholds. Beyond the last level XP keeps counting.
 export const LEVELS = [

--- a/wortwerkstatt/js/i18n.js
+++ b/wortwerkstatt/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=8";
-import { de } from "./i18n/de.js?v=8";
-import { en } from "./i18n/en.js?v=8";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=9";
+import { de } from "./i18n/de.js?v=9";
+import { en } from "./i18n/en.js?v=9";
 
 export const TABLES = { de, en };
 

--- a/wortwerkstatt/js/i18n/de.js
+++ b/wortwerkstatt/js/i18n/de.js
@@ -117,6 +117,7 @@ export const de = {
   actionCheck: "Fertig",
   writeConfirmHint: "Schreib den ganzen Satz.",
   writeAutoHint: "Sobald der Satz fertig aussieht, prüft die App ihn. Sonst tipp auf Fertig.",
+  writeEditHint: "Ändere in Ruhe, was nicht stimmt, und tipp dann auf Fertig. Stimmt alles, siehst du es sofort.",
   memoryTypedWords: "Du hast geschrieben. Die markierten Wörter stimmen noch nicht:",
   actionRetry: "Nochmals versuchen",
   actionReveal: "Lösung zeigen",

--- a/wortwerkstatt/js/i18n/en.js
+++ b/wortwerkstatt/js/i18n/en.js
@@ -117,6 +117,7 @@ export const en = {
   actionCheck: "Done",
   writeConfirmHint: "Write the whole sentence.",
   writeAutoHint: "As soon as the sentence looks finished, the app checks it. Otherwise tap Done.",
+  writeEditHint: "Take your time fixing what is not right, then tap Done. When it is all right, you see it straight away.",
   memoryTypedWords: "What you wrote. The marked words are not right yet:",
   actionRetry: "Try again",
   actionReveal: "Show the answer",

--- a/wortwerkstatt/js/round.js
+++ b/wortwerkstatt/js/round.js
@@ -4,7 +4,7 @@
 // module directly to derive the expected answers, so the tests can
 // never drift from the engine.
 
-import { shuffle } from "./util.js?v=8";
+import { shuffle } from "./util.js?v=9";
 
 export const ROUND_SIZE = 6;
 
@@ -57,9 +57,14 @@ function wordCount(value) {
 // too few or too many words is indistinguishable from one that is still
 // being typed. Judging that would be judging characters as they are
 // typed, which recall must never become.
-export function looksComplete(expected, typed) {
+export function looksComplete(expected, typed, { editing = false } = {}) {
   const value = normaliseTyped(typed);
   if (value === expected) return true;
+  // While correcting a sentence that is already on screen, only a right
+  // one is judged. A correction often takes several edits, and judging
+  // the shape after each keystroke answers "still wrong" over and over
+  // before the child has finished. They say when they are done.
+  if (editing) return false;
   if (!/[.!?]$/.test(value)) return false;
   return wordCount(value) === wordCount(expected);
 }

--- a/wortwerkstatt/js/storage.js
+++ b/wortwerkstatt/js/storage.js
@@ -4,7 +4,7 @@
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   DEFAULT_LANGUAGE, DEFAULT_CONTENT_LANGUAGE, DEFAULT_CYCLE
-} from "./data.js?v=8";
+} from "./data.js?v=9";
 
 const KEY = "wortwerkstatt.state";
 

--- a/wortwerkstatt/js/ui.js
+++ b/wortwerkstatt/js/ui.js
@@ -4,18 +4,18 @@
 // i18n; every practice string comes from the content pack and is
 // marked with the content language so screen readers switch voice.
 
-import { icon } from "./icons.js?v=8";
+import { icon } from "./icons.js?v=9";
 import {
   LANGUAGES, CONTENT_LANGUAGES, CYCLES,
   contentByCode, topicsForCycle, topicById, topicKey,
   textsForCycle, textById, textKey, LEHRPLAN_VERSION
-} from "./data.js?v=8";
-import { t, currentLanguage } from "./i18n.js?v=8";
-import { escapeHtml, statusOf, topicStatus } from "./util.js?v=8";
+} from "./data.js?v=9";
+import { t, currentLanguage } from "./i18n.js?v=9";
+import { escapeHtml, statusOf, topicStatus } from "./util.js?v=9";
 import {
   fillTask, expectedAnswer, letterDiff, wordDiff, isTyped, needsConfirm, ROUND_SIZE
-} from "./round.js?v=8";
-import { MEDALS, levelFor } from "./game.js?v=8";
+} from "./round.js?v=9";
+import { MEDALS, levelFor } from "./game.js?v=9";
 
 // Sentinel put in place of the answer so the blank lands exactly where
 // round.js says it does, spacing included. A control character, because
@@ -537,7 +537,9 @@ function renderTypedTask(state, task, r) {
                autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false"
                inputmode="text" data-autofocus${contentLangAttr(state)}>
         <p class="hint">${confirm ? t("writeConfirmHint") : t("memoryLetters", { n: answer.length })}</p>
-        <p class="hint">${confirm ? t("writeAutoHint") : t("memoryAutoHint")}</p>
+        <p class="hint">${confirm
+          ? t(r.editing ? "writeEditHint" : "writeAutoHint")
+          : t("memoryAutoHint")}</p>
       </div>
       ${confirm ? `<button type="button" class="btn btn-primary btn-wide" data-action="check">${t("actionCheck")}</button>` : ""}`;
   } else if (r.phase === "correct") {

--- a/wortwerkstatt/tests/e2e.test.mjs
+++ b/wortwerkstatt/tests/e2e.test.mjs
@@ -22,13 +22,13 @@ import { fileURLToPath } from "node:url";
 import {
   CONTENT_LANGUAGES, CYCLES, topicsForCycle, topicKey,
   textsForCycle, textKey, LEHRPLAN_VERSION
-} from "../js/data.js?v=8";
-import { TABLES } from "../js/i18n.js?v=8";
+} from "../js/data.js?v=9";
+import { TABLES } from "../js/i18n.js?v=9";
 import {
   fillTask, expectedAnswer, solutionText, isTyped, needsConfirm, wordDiff,
   looksComplete, ROUND_SIZE
-} from "../js/round.js?v=8";
-import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=8";
+} from "../js/round.js?v=9";
+import { MEDALS, xpForRound, levelFor } from "../js/game.js?v=9";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -258,6 +258,25 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   }
   check("no half-typed sentence is ever judged on its own", halfProblems.length === 0,
     halfProblems.slice(0, 4).join(" | "));
+
+  // While correcting, only a right sentence is judged: a correction
+  // often takes several edits, and the shape check would answer "still
+  // wrong" after each one.
+  const editProblems = [];
+  for (const item of CONTENT.texts.flatMap((text) => text.sentences)) {
+    const halfFixed = item.answer.replace(/^(\S+)/, (w) => w.toLowerCase());
+    if (looksComplete(item.answer, halfFixed, { editing: true })) {
+      editProblems.push(`${item.answer}: judged mid-correction`);
+    }
+    if (!looksComplete(item.answer, item.answer, { editing: true })) {
+      editProblems.push(`${item.answer}: a finished correction was not accepted`);
+    }
+    if (!looksComplete(item.answer, halfFixed)) {
+      editProblems.push(`${item.answer}: a fresh attempt stopped being judged`);
+    }
+  }
+  check("correcting is never judged until it is right, writing fresh still is",
+    editProblems.length === 0, editProblems.slice(0, 4).join(" | "));
 
   // Marking is aligned, not positional. One slip must cost one mark,
   // however early in the sentence it happens, or a child sees a wall of
@@ -693,82 +712,79 @@ try {
     (await count(".para-line.current .icon")) === 1);
   await shot("27-text-start");
 
-  // A miss first: the letter comparison has to work on a whole sentence.
+
+  const full = firstText.sentences[0].answer;
+
+  /* ── Sentence 1, fresh: judged as soon as it looks finished ─────── */
+  check("a sentence is confirmed, not auto-checked",
+    (await count('[data-action="check"]')) === 1);
+  check("the field leaves room to overshoot, so a too-long answer is possible",
+    Number(await page.getAttribute("#answer", "maxlength")) > full.length);
   await writeAnswer("text", firstText.sentences[0].prompt + ".");
   check("a wrong sentence is answered at once", (await count(".feedback-warn")) === 1);
-  // A sentence comes back by word: a single slip must not paint every
-  // later character red.
   // Cell count comes from the aligner, not from the sentence length: a
   // dropped word shows a gap, so the two need not match.
-  const backCells = wordDiff(firstText.sentences[0].answer, firstText.sentences[0].prompt + ".").rows.length;
+  const backCells = wordDiff(full, firstText.sentences[0].prompt + ".").rows.length;
   check("the whole sentence is shown back word by word",
     (await count(".word")) === backCells, `${await count(".word")} cells, expected ${backCells}`);
   check("the missed words are marked", (await count(".word.miss")) > 0);
   check("a sentence is never shown back character by character",
     (await count(".letter")) === 0);
   await shot("28-text-miss");
-  await page.click('[data-action="retry"]');
 
-  // The bug this guards: with a self-checking field an answer one
-  // character short never reaches the expected length, so the check
-  // never fires and the child is stuck with no response at all.
-  const full = firstText.sentences[0].answer;
-  const shortOne = full.replace(".", "");
-  check("a sentence is confirmed, not auto-checked",
-    (await count('[data-action="check"]')) === 1);
-  check("the field leaves room to overshoot, so a too-long answer is possible",
-    Number(await page.getAttribute("#answer", "maxlength")) > full.length);
-  await page.fill("#answer", "");
-  await page.type("#answer", shortOne);
-  check("an answer one character short does not judge itself",
-    (await count(".feedback-warn")) === 0 && (await count(".feedback-success")) === 0);
-  await page.click('[data-action="check"]');
-  check("confirming an answer one character short is answered",
-    (await count(".feedback-warn")) === 1);
-  check("a sentence comes back word by word, not character by character",
-    (await count(".word")) > 0 && (await count(".letter")) === 0);
-  check("only the word that is actually wrong is marked",
-    (await count(".word.miss")) === 1, `${await count(".word.miss")} marked`);
-  await shot("28b-text-missing-character");
-  await page.click('[data-action="retry"]');
-
-  // A sentence that looks finished is judged without the button. The
-  // button exists for everything that cannot be told apart from a
-  // sentence still being typed.
-  await page.fill("#answer", "");
-  const smallStart = full.replace(/^(\S+)/, (w) => w.toLowerCase());
-  await page.type("#answer", smallStart);
-  check("a finished sentence with a small letter is judged without the button",
-    (await count(".feedback-warn")) === 1);
-  check("and it marks only the word that is wrong",
-    (await count(".word.miss")) === 1, `${await count(".word.miss")} marked`);
+  /* ── Sentence 1, correcting: never judged until it is right ─────── */
+  // A correction often takes several edits. Judging the shape after
+  // each keystroke answers "still wrong" over and over, which is the
+  // bug this guards.
   await page.click('[data-action="retry"]');
   check("a retry keeps the sentence, so one slip is not a full retype",
-    (await page.inputValue("#answer")) === smallStart);
+    (await page.inputValue("#answer")) === firstText.sentences[0].prompt + ".");
   check("the caret sits after what was written", await page.evaluate(() => {
     const el = document.getElementById("answer");
     return el.selectionStart === el.value.length;
   }));
+  check("the advisory line says the child decides when to check",
+    (await text(".answer-field .hint:last-child")).includes("Fertig"),
+    await text(".answer-field .hint:last-child"));
 
-  // Enter is the same button where one exists. Driven on an answer the
-  // auto-check deliberately leaves alone, so it is Enter doing the work.
+  const lastWordSmall = full.replace(/(\S+)(\.)$/, (m, w, dot) => w.toLowerCase() + dot);
   await page.fill("#answer", "");
-  await page.type("#answer", shortOne);
-  check("the answer Enter is tested on is not auto-judged",
+  await page.type("#answer", lastWordSmall);
+  check("fixing part of it while correcting is not judged",
+    (await count(".feedback-warn, .feedback-success")) === 0);
+  check("the button is still there to do it",
+    (await count('[data-action="check"]')) === 1);
+  await shot("28c-text-correcting");
+  await page.click('[data-action="check"]');
+  check("confirming mid-correction answers what is left",
+    (await count(".word.miss")) === 1, `${await count(".word.miss")} marked`);
+
+  // A correction that lands right still needs no button.
+  await page.click('[data-action="retry"]');
+  await page.fill("#answer", "");
+  await page.type("#answer", full);
+  check("a correction that lands right is accepted without the button",
+    (await count(".feedback-success")) === 1);
+  check("a right sentence never shows a wrong word", (await count(".word.miss")) === 0);
+  await shot("29b-text-auto-accepted");
+  await page.click('[data-action="next"]');
+
+  /* ── Sentence 2, fresh: the shape rule and Enter ─────────────────── */
+  // The bug the confirm button exists for: an answer one character
+  // short never reaches the expected length, so a self-checking field
+  // would leave the child with no response at all.
+  const second = firstText.sentences[1].answer;
+  await page.fill("#answer", "");
+  await page.type("#answer", second.replace(/[.!?]$/, ""));
+  check("an answer one character short does not judge itself",
     (await count(".feedback-warn, .feedback-success")) === 0);
   await page.keyboard.press("Enter");
   check("Enter confirms a sentence", (await count(".feedback-warn")) === 1);
-  await page.click('[data-action="retry"]');
-
-  // Exactly right needs no button at all, which is the path a child who
-  // writes it correctly actually takes.
-  await page.fill("#answer", "");
-  await page.type("#answer", full);
-  check("an exactly right sentence is accepted without the button",
-    (await count(".feedback-success")) === 1);
-  check("a right sentence never shows a wrong word",
-    (await count(".word.miss")) === 0);
-  await shot("29b-text-auto-accepted");
+  check("a sentence comes back word by word, not character by character",
+    (await count(".word")) > 0 && (await count(".letter")) === 0);
+  check("only the mark that is missing is marked",
+    (await count(".word.miss")) === 1, `${await count(".word.miss")} marked`);
+  await shot("28b-text-missing-character");
 
   // Back to the start of the text, so the write-through below runs from
   // sentence one.


### PR DESCRIPTION
Fixes a reported interruption: after **Nochmals versuchen**, fixing a single letter judged the sentence again — even though several corrections were still needed.

**Live once merged:** https://lfdave.github.io/small-apps/wortwerkstatt/index.html?r=20260803-9

## The cause

Keeping the sentence on a retry was the right call, but it left the shape rule running. Same word count, still ends on a mark — so every keystroke of a multi-word correction was answered *"still wrong"* before the child had finished.

## The fix

While a retry has kept the sentence on screen, the child is **editing**, not writing it out. The shape rule switches off and they say when they're done:

| State | `das lernen …` typed | Fixing one word | Fully fixed |
|---|---|---|---|
| **Fresh** | judged (looks finished) | — | accepted |
| **Correcting** | — | **waits** | accepted |

Only an exactly right sentence is still judged on its own, so a correction that lands right is accepted at once and **no wrong verdict ever interrupts one in progress**. Clearing the field — a reveal, or the next task — makes it fresh writing again.

The advisory line changes with it (*"Ändere in Ruhe, was nicht stimmt, und tipp dann auf Fertig. Stimmt alles, siehst du es sofort."*), so the behaviour is announced before use rather than switching silently (WCAG 3.2.2).

## Testing

**193 checks pass.** Pinned twice:

- Over **every sentence in the pack**: a half-corrected one may not be judged, a finished one must be, and a fresh attempt must still be judged on its shape.
- In the browser: fixing part of a sentence after a retry produces no verdict, the button is still there, confirming mid-correction answers what's left, and fixing it fully is accepted without the button.

The text-mode block of the suite is **regrouped into phases** — fresh sentence, then correcting it, then a fresh one again. A retry now changes how the next keystroke is treated, so checks written for a fresh attempt genuinely cannot run mid-correction; leaving them interleaved would have made them pass or fail for the wrong reasons.

## Docs

`PRD.md`, `CLAUDE.md` and `README.md` — each verified present after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYaiUfJ3Qks8u6AbQ3abQ1)_