### PR TITLE
Stop the first clue from deciding the round in Tierraten

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ A calm spelling trainer for kids, built on one Lehrplan 21 competency (D.4 Schre
 A calm animal guessing game for children. One animal is described clue by clue until you recognise it, and the game walks through the alphabet from A to Z.
 
 **Features:**
-- 84 animals, from the ant to the zebra, each with a full row of checkable facts
+- 172 animals, from the ant to the zebra, each with a full row of checkable facts
 - Nine clues in a fixed ladder: continent, a country with its flag, habitat, body, mammal or egg, food, covering, colour, and the second letter of the name
 - Guess from the first clue on; the earlier you get it, the more you earn
+- Letters are stocked in continent pairs and the four names offered are the ones hardest to tell apart, so the first clue almost never settles the round
 - A wrong guess costs nothing and keeps the turn open, and the answer is always one tap away
 - Two ways to answer: tap one of four names, or write it yourself and watch it lock in the moment it is spelled right
 - The alphabet follows the language, so the squirrel sits under E in German and under S in English

--- a/tierraten/CLAUDE.md
+++ b/tierraten/CLAUDE.md
@@ -17,6 +17,12 @@ spec-sync rules, cache-busting convention) applies as well.
   labels. Labels live in `js/i18n/` and are looked up by convention:
   `valueKey("color", "schwarz-weiss")` is `colorSchwarzWeiss`. Adding a
   value without its label is a test failure, not a silent fallback.
+- **Add animals in continent pairs, within a letter.** A letter holding
+  one African animal is a letter the first clue solves. Never add a
+  species without a partner from its own continent under the same letter
+  — add two, or add neither. The suite counts what is left alone and
+  holds the line at the current floor (10 in German, 25 in English); it
+  may improve, never regress.
 - **Do not invent facts.** Every row is the ordinary checkable kind, and
   a parent must be able to hold it against a field guide. `country` is
   *one* country the species really occurs in and is labelled "Zum
@@ -65,6 +71,13 @@ spec-sync rules, cache-busting convention) applies as well.
   Never widen the auto-check, and never add a length hint.
 - **The `input` handler must not re-render** on a non-matching value, or
   the caret jumps mid-word.
+- **`optionsFor` ranks, it does not sample.** Distractors are the
+  same-letter animals with the longest `sharedPrefix` — the run of
+  *leading* clues they share with the answer. Picking at random is what
+  made the game give itself away, and the suite checks, for every animal
+  in both languages, that the board is the closest set the letter can
+  offer. Never replace it with a plain shuffle, and never let it skip a
+  same-continent partner the letter has.
 - `js/round.js` is pure: picking animals, building options, finding the
   next letter. `js/game.js` is pure: XP, levels, medals. Neither touches
   the DOM or a string.

--- a/tierraten/PRD.md
+++ b/tierraten/PRD.md
@@ -70,8 +70,10 @@ has to work in English, and a labelled row reads the same in both.
 
 Two modes, a setting (`answerMode`), default **choose**:
 
-- **choose** — four names to tap: the animal plus three others, taken
-  from the same letter first so the clues decide and not the initial.
+- **choose** — four names to tap: the animal plus the three others from
+  its letter whose early clues match it most closely, so the choice is
+  decided by reading down the ladder rather than by the initial or by the
+  first clue. See "The first clue must not be the whole game" below.
   Spelling "Eichhörnchen" is a second task on top of the one the game is
   about, and the primary audience is children.
 - **type** — the name is written. The guess is judged as a whole word,
@@ -86,7 +88,8 @@ Two modes, a setting (`answerMode`), default **choose**:
 A typed guess is matched on letters alone: case, spaces and hyphens fall
 away, and both readings of an umlaut are produced, so "Kaenguru",
 "Kanguru" and "Känguru" all reach the same animal. Listed alternatives
-(`alt`) are accepted too: Delphin, Flusspferd, Rhino, Blauwal, Jak.
+(`alt`) are accepted too: Delphin, Flusspferd, Rhino, Blauwal, Jak,
+Beluga, Gams, Ladybug, Pikeperch, Bactrian camel.
 
 ## The alphabet walk
 
@@ -111,9 +114,36 @@ and marked "Kein Tier", with a line under the grid saying what that
 means. Naming the gap is the honest answer; the alternative is an obscure
 genus name dressed up as a common name.
 
+## The first clue must not be the whole game
+
+A letter that holds exactly one African animal is a letter the first clue
+solves: the board shows it beside three animals from three other
+continents and "Afrika" ends the round before it starts. The ladder only
+works if the early clues leave the child with more than one candidate.
+Two things carry that, and both are enforced by the e2e suite.
+
+**The fact table stocks letters in continent pairs.** A species is added
+with a partner from its own continent or not at all. In German 10 of 172
+animals are still alone in their letter, all of them in letters the
+animal kingdom simply does not fill (C, J, Q, U, V, Y); in English, whose
+alphabet cuts the same set differently, 25 are.
+
+**The option picker spends the pairs it has.** Candidates are ranked by
+`sharedPrefix` — how many *leading* clues they share with the answer —
+and the closest fill the board. Two African animals score at least 1, two
+African animals from the same country at least 2. Ties stay shuffled, so
+an animal does not always arrive with the same company. The result: clue
+one splits the board for 3 of 172 animals in German and 13 in English,
+and in none of those cases did the letter hold a partner the picker could
+have used.
+
+A letter too thin to fill the board borrows names from the rest of the
+pool. Their initial gives them away, but a letter with one animal has no
+honest alternative, and the borrowed names are ranked the same way.
+
 ## Content
 
-84 animals in `js/animals.js`. Every field holds a stable id; labels live
+172 animals in `js/animals.js`. Every field holds a stable id; labels live
 in `js/i18n/` and change with the language.
 
 - Facts are the ordinary checkable kind: range, habitat, body plan, diet,
@@ -128,8 +158,9 @@ in `js/i18n/` and change with the language.
 
 Guaranteed by the e2e suite: every field value comes from its own list,
 every listed value carries a label in every language and is actually
-used, no two animals answer to the same spelling in one language, and no
-two animals present an identical row of all nine clues.
+used, no two animals answer to the same spelling in one language, no two
+animals present an identical row of all nine clues, and the picker never
+leaves a same-continent partner on the bench.
 
 ## Progression
 

--- a/tierraten/README.md
+++ b/tierraten/README.md
@@ -19,7 +19,10 @@ Guess whenever you like. The earlier you get it, the more you earn. A
 wrong guess costs nothing and the turn stays open. If you would rather
 just see it, **Auflösen** shows the answer and the round carries on.
 
-84 animals, from the ant to the zebra.
+172 animals, from the ant to the zebra. The four names you get to choose
+between always come from the same letter and are picked to be hard to
+tell apart early: if the animal lives in Africa, so does at least one of
+the others, so the first clue rarely settles it.
 
 ## How to play
 

--- a/tierraten/css/styles.css
+++ b/tierraten/css/styles.css
@@ -10,14 +10,14 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=1") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-400.woff2?v=2") format("woff2");
 }
 @font-face {
   font-family: "Atkinson Hyperlegible";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=1") format("woff2");
+  src: url("../fonts/atkinson-hyperlegible-700.woff2?v=2") format("woff2");
 }
 
 :root {

--- a/tierraten/index.html
+++ b/tierraten/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="Tierraten: Hinweis für Hinweis ein Tier erraten, Buchstabe für Buchstabe durch das Alphabet.">
   <title>Tierraten</title>
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="css/styles.css?v=1">
+  <link rel="stylesheet" href="css/styles.css?v=2">
 </head>
 <body>
   <main id="app" aria-live="off"></main>
   <noscript>
     <p style="padding: 1rem; color: #F5F7FA;">Tierraten braucht JavaScript.</p>
   </noscript>
-  <script type="module" src="js/app.js?v=1"></script>
+  <script type="module" src="js/app.js?v=2"></script>
 </body>
 </html>

--- a/tierraten/js/animals.js
+++ b/tierraten/js/animals.js
@@ -13,8 +13,14 @@
 // it eats, how it is covered. `country` is one country the animal really
 // occurs in, shown as an example and labelled as one, never as "the"
 // country of a species. Nothing here is invented; where a species would
-// need a hedge (sharks that bear live young, for instance) the species
-// is left out rather than squeezed into the binary.
+// need a hedge (sharks and vipers that bear live young, salamanders that
+// drop larvae) the species is left out rather than squeezed into the
+// mammal-or-egg step.
+//
+// **Letters are stocked in continent pairs.** A letter where only one
+// animal lives in Africa is a letter the very first clue solves, so a
+// species is added with a partner from its own continent or not at all.
+// The e2e suite counts what is left over and holds the line.
 
 export const CONTINENTS = [
   "afrika", "asien", "europa", "nordamerika", "suedamerika",
@@ -28,7 +34,8 @@ export const HABITATS = [
 
 export const BODIES = [
   "keine-beine", "flossen", "zwei-beine", "zwei-beine-fluegel",
-  "vier-beine", "sechs-beine", "sechs-beine-fluegel", "acht-beine", "acht-arme"
+  "vier-beine", "sechs-beine", "sechs-beine-fluegel", "acht-beine",
+  "zehn-beine", "fuenf-arme", "acht-arme"
 ];
 
 export const BIRTHS = ["saeugetier", "eier"];
@@ -42,123 +49,236 @@ export const COLORS = [
   "schwarz", "weiss", "schwarz-weiss", "schwarz-braun", "orange-schwarz",
   "gelb-schwarz", "rot-schwarz", "rot", "gruen", "gruen-braun", "bunt", "rosa",
   "gelb", "blau-grau", "durchsichtig", "orange-weiss", "weiss-braun",
-  "grau-gelb", "blau-orange"
+  "grau-gelb", "grau-rot", "blau-orange"
 ];
 
 // ISO 3166-1 alpha-2, lowercase, so the flag image follows the code.
 export const COUNTRIES = [
-  "at", "au", "bo", "br", "ca", "cd", "ch", "cn", "de", "eg", "es", "gr",
-  "in", "is", "ke", "mg", "na", "nl", "no", "pe", "pl", "ro", "sy",
+  "at", "au", "bo", "br", "ca", "cd", "ch", "cm", "cn", "de", "eg", "es",
+  "gr", "in", "is", "ke", "mg", "na", "nl", "no", "pe", "pk", "pl", "ro",
   "tz", "us", "za"
 ];
 
 export const ANIMALS = [
+  /* ── A ── europa 5, suedamerika 2, afrika 2 ───────────────────── */
   { id: "adler", name: { de: "Adler", en: "Eagle" }, continent: "europa", country: "ch", habitat: "berge", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
-  { id: "ameise", name: { de: "Ameise", en: "Ant" }, continent: "weltweit", country: "de", habitat: "wald", body: "sechs-beine", birth: "eier", food: "beides", cover: "panzer", color: "schwarz" },
+  { id: "ameise", name: { de: "Ameise", en: "Ant" }, continent: "europa", country: "de", habitat: "wald", body: "sechs-beine", birth: "eier", food: "beides", cover: "panzer", color: "schwarz" },
+  { id: "amsel", name: { de: "Amsel", en: "Blackbird" }, continent: "europa", country: "de", habitat: "stadt", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "schwarz" },
+  { id: "auerhahn", name: { de: "Auerhahn", en: "Capercaillie" }, continent: "europa", country: "at", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "schwarz" },
+  { id: "aal", name: { de: "Aal", en: "Eel" }, continent: "europa", country: "nl", habitat: "suesswasser", body: "flossen", birth: "eier", food: "fleisch", cover: "schuppen", color: "braun" },
+  { id: "austernfischer", name: { de: "Austernfischer", en: "Oystercatcher" }, continent: "europa", country: "nl", habitat: "meer", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "schwarz-weiss" },
   { id: "ameisenbaer", name: { de: "Ameisenbär", en: "Anteater" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "fell", color: "grau" },
   { id: "alpaka", name: { de: "Alpaka", en: "Alpaca" }, continent: "suedamerika", country: "pe", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "wolle", color: "braun" },
+  { id: "antilope", name: { de: "Antilope", en: "Antelope" }, continent: "afrika", country: "na", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gelb-braun" },
+  { id: "aasgeier", name: { de: "Aasgeier", en: "Egyptian vulture" }, continent: "afrika", country: "eg", habitat: "wueste", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "weiss" },
 
+  /* ── B ── europa 5, nordamerika 2 ─────────────────────────────── */
   { id: "baer", name: { de: "Bär", en: "Bear" }, continent: "europa", country: "ro", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "braun" },
   { id: "biene", name: { de: "Biene", en: "Bee" }, continent: "europa", country: "ch", habitat: "wiese", body: "sechs-beine-fluegel", birth: "eier", food: "nektar", cover: "panzer", color: "gelb-schwarz" },
+  { id: "bussard", name: { de: "Bussard", en: "Buzzard" }, continent: "europa", country: "de", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
+  { id: "buntspecht", name: { de: "Buntspecht", en: "Woodpecker" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "schwarz-weiss" },
+  { id: "blaumeise", name: { de: "Blaumeise", en: "Blue tit" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "bunt" },
   { id: "biber", name: { de: "Biber", en: "Beaver" }, continent: "nordamerika", country: "ca", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "bison", name: { de: "Bison", en: "Bison" }, continent: "nordamerika", country: "us", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
 
+  /* ── C ── a thin letter: three animals, three continents ──────── */
   { id: "chamaeleon", name: { de: "Chamäleon", en: "Chameleon" }, continent: "afrika", country: "mg", habitat: "wald", body: "vier-beine", birth: "eier", food: "insekten", cover: "schuppen", color: "gruen" },
   { id: "clownfisch", name: { de: "Clownfisch", en: "Clownfish" }, continent: "ozeane", country: "au", habitat: "meer", body: "flossen", birth: "eier", food: "beides", cover: "schuppen", color: "orange-weiss" },
+  { id: "chinchilla", name: { de: "Chinchilla", en: "Chinchilla" }, continent: "suedamerika", country: "bo", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "grau" },
 
-  { id: "delfin", name: { de: "Delfin", en: "Dolphin" }, alt: { de: ["Delphin"] }, continent: "ozeane", country: "gr", habitat: "meer", body: "flossen", birth: "saeugetier", food: "fisch", cover: "haut", color: "grau" },
+  /* ── D ── europa 4, ozeane 2, afrika 2 ───────────────────────── */
   { id: "dachs", name: { de: "Dachs", en: "Badger" }, continent: "europa", country: "de", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "schwarz-weiss" },
+  { id: "dohle", name: { de: "Dohle", en: "Jackdaw" }, continent: "europa", country: "ch", habitat: "stadt", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "schwarz" },
+  { id: "distelfink", name: { de: "Distelfink", en: "Goldfinch" }, continent: "europa", country: "de", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "bunt" },
+  { id: "damhirsch", name: { de: "Damhirsch", en: "Fallow deer" }, continent: "europa", country: "de", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gelb-braun" },
+  { id: "delfin", name: { de: "Delfin", en: "Dolphin" }, alt: { de: ["Delphin"] }, continent: "ozeane", country: "gr", habitat: "meer", body: "flossen", birth: "saeugetier", food: "fisch", cover: "haut", color: "grau" },
+  { id: "dugong", name: { de: "Dugong", en: "Dugong" }, continent: "ozeane", country: "au", habitat: "meer", body: "flossen", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "grau" },
   { id: "dromedar", name: { de: "Dromedar", en: "Dromedary" }, continent: "afrika", country: "eg", habitat: "wueste", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gold-braun" },
+  { id: "dikdik", name: { de: "Dikdik", en: "Dik-dik" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
 
-  { id: "elefant", name: { de: "Elefant", en: "Elephant" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "grau" },
+  /* ── E ── europa 7, afrika 2, arktis 2 ───────────────────────── */
   { id: "eichhoernchen", name: { de: "Eichhörnchen", en: "Squirrel" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "rotbraun" },
   { id: "ente", name: { de: "Ente", en: "Duck" }, continent: "europa", country: "nl", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "bunt" },
-  { id: "eisbaer", name: { de: "Eisbär", en: "Polar bear" }, continent: "arktis", country: "no", habitat: "eis", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "weiss" },
   { id: "esel", name: { de: "Esel", en: "Donkey" }, continent: "europa", country: "es", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "grau" },
+  { id: "eisvogel", name: { de: "Eisvogel", en: "Kingfisher" }, continent: "europa", country: "at", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "fisch", cover: "federn", color: "bunt" },
+  { id: "elch", name: { de: "Elch", en: "Moose" }, continent: "europa", country: "no", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
+  { id: "elster", name: { de: "Elster", en: "Magpie" }, continent: "europa", country: "ch", habitat: "stadt", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "schwarz-weiss" },
+  { id: "eidechse", name: { de: "Eidechse", en: "Lizard" }, continent: "europa", country: "ch", habitat: "wiese", body: "vier-beine", birth: "eier", food: "insekten", cover: "schuppen", color: "gruen" },
+  { id: "elefant", name: { de: "Elefant", en: "Elephant" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "grau" },
+  { id: "erdmaennchen", name: { de: "Erdmännchen", en: "Meerkat" }, continent: "afrika", country: "na", habitat: "wueste", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "fell", color: "braun" },
+  { id: "erdferkel", name: { de: "Erdferkel", en: "Aardvark" }, continent: "afrika", country: "za", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "haut", color: "rosa" },
+  { id: "eisbaer", name: { de: "Eisbär", en: "Polar bear" }, continent: "arktis", country: "no", habitat: "eis", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "weiss" },
+  { id: "eismoewe", name: { de: "Eismöwe", en: "Glaucous gull" }, continent: "arktis", country: "no", habitat: "meer", body: "zwei-beine-fluegel", birth: "eier", food: "fisch", cover: "federn", color: "weiss" },
 
+  /* ── F ── europa 5, afrika 2 ─────────────────────────────────── */
   { id: "fuchs", name: { de: "Fuchs", en: "Fox" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "rot" },
-  { id: "flamingo", name: { de: "Flamingo", en: "Flamingo" }, continent: "afrika", country: "ke", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "plankton", cover: "federn", color: "rosa" },
   { id: "frosch", name: { de: "Frosch", en: "Frog" }, continent: "europa", country: "de", habitat: "suesswasser", body: "vier-beine", birth: "eier", food: "insekten", cover: "haut", color: "gruen" },
   { id: "fledermaus", name: { de: "Fledermaus", en: "Bat" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "saeugetier", food: "insekten", cover: "fell", color: "braun" },
+  { id: "forelle", name: { de: "Forelle", en: "Trout" }, continent: "europa", country: "ch", habitat: "suesswasser", body: "flossen", birth: "eier", food: "insekten", cover: "schuppen", color: "braun" },
+  { id: "flusskrebs", name: { de: "Flusskrebs", en: "Crayfish" }, continent: "europa", country: "at", habitat: "suesswasser", body: "zehn-beine", birth: "eier", food: "beides", cover: "panzer", color: "braun" },
+  { id: "flamingo", name: { de: "Flamingo", en: "Flamingo" }, continent: "afrika", country: "ke", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "plankton", cover: "federn", color: "rosa" },
+  { id: "fennek", name: { de: "Fennek", en: "Fennec fox" }, continent: "afrika", country: "eg", habitat: "wueste", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gold-braun" },
 
+  /* ── G ── afrika 4, europa 3 ─────────────────────────────────── */
   { id: "giraffe", name: { de: "Giraffe", en: "Giraffe" }, continent: "afrika", country: "tz", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gelb-braun" },
   { id: "gorilla", name: { de: "Gorilla", en: "Gorilla" }, continent: "afrika", country: "cd", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz" },
-  { id: "gans", name: { de: "Gans", en: "Goose" }, continent: "europa", country: "de", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "grau" },
   { id: "gepard", name: { de: "Gepard", en: "Cheetah" }, continent: "afrika", country: "na", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gelb-gefleckt" },
+  { id: "gnu", name: { de: "Gnu", en: "Wildebeest" }, continent: "afrika", country: "tz", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "grau" },
+  { id: "gans", name: { de: "Gans", en: "Goose" }, continent: "europa", country: "de", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "grau" },
   { id: "geier", name: { de: "Geier", en: "Vulture" }, continent: "europa", country: "es", habitat: "berge", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
+  { id: "gaemse", name: { de: "Gämse", en: "Chamois" }, alt: { de: ["Gams"] }, continent: "europa", country: "ch", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
 
+  /* ── H ── weltweit 3, europa 3, afrika 2 ─────────────────────── */
   { id: "hund", name: { de: "Hund", en: "Dog" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "braun" },
-  { id: "hase", name: { de: "Hase", en: "Hare" }, continent: "europa", country: "de", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "huhn", name: { de: "Huhn", en: "Chicken" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "braun" },
-  { id: "hamster", name: { de: "Hamster", en: "Hamster" }, continent: "asien", country: "sy", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gold-braun" },
+  { id: "hamster", name: { de: "Hamster", en: "Hamster" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gold-braun" },
+  { id: "hase", name: { de: "Hase", en: "Hare" }, continent: "europa", country: "de", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "hirsch", name: { de: "Hirsch", en: "Deer" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "rotbraun" },
+  { id: "hirschkaefer", name: { de: "Hirschkäfer", en: "Stag beetle" }, continent: "europa", country: "de", habitat: "wald", body: "sechs-beine-fluegel", birth: "eier", food: "pflanzen", cover: "panzer", color: "schwarz-braun" },
+  { id: "hyaene", name: { de: "Hyäne", en: "Hyena" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gold-braun" },
+  { id: "honigdachs", name: { de: "Honigdachs", en: "Honey badger" }, continent: "afrika", country: "za", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "schwarz-weiss" },
 
+  /* ── I ── europa 2, afrika 2 ─────────────────────────────────── */
   { id: "igel", name: { de: "Igel", en: "Hedgehog" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "stacheln", color: "braun" },
   { id: "iltis", name: { de: "Iltis", en: "Polecat" }, continent: "europa", country: "de", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "schwarz-braun" },
   { id: "ibis", name: { de: "Ibis", en: "Ibis" }, continent: "afrika", country: "eg", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "schwarz-weiss" },
   { id: "impala", name: { de: "Impala", en: "Impala" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "rotbraun" },
 
+  /* ── J ── the thinnest letter in German ──────────────────────── */
   { id: "jaguar", name: { de: "Jaguar", en: "Jaguar" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gelb-gefleckt" },
 
+  /* ── K ── europa 3, australien 2, weltweit 2, afrika 2, suedamerika 2 ── */
+  { id: "kuh", name: { de: "Kuh", en: "Cow" }, continent: "europa", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz-weiss" },
+  { id: "kiebitz", name: { de: "Kiebitz", en: "Lapwing" }, continent: "europa", country: "nl", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "schwarz-weiss" },
+  { id: "karpfen", name: { de: "Karpfen", en: "Carp" }, continent: "europa", country: "de", habitat: "suesswasser", body: "flossen", birth: "eier", food: "beides", cover: "schuppen", color: "gold-braun" },
   { id: "kaenguru", name: { de: "Känguru", en: "Kangaroo" }, alt: { de: ["Känguruh"] }, continent: "australien", country: "au", habitat: "wiese", body: "zwei-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "rotbraun" },
   { id: "koala", name: { de: "Koala", en: "Koala" }, continent: "australien", country: "au", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "grau" },
   { id: "katze", name: { de: "Katze", en: "Cat" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "grau" },
+  { id: "kakerlake", name: { de: "Kakerlake", en: "Cockroach" }, continent: "weltweit", country: "de", habitat: "zuhause", body: "sechs-beine", birth: "eier", food: "beides", cover: "panzer", color: "braun" },
   { id: "krokodil", name: { de: "Krokodil", en: "Crocodile" }, continent: "afrika", country: "eg", habitat: "suesswasser", body: "vier-beine", birth: "eier", food: "fleisch", cover: "schuppen", color: "gruen" },
-  { id: "kuh", name: { de: "Kuh", en: "Cow" }, continent: "europa", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz-weiss" },
+  { id: "kudu", name: { de: "Kudu", en: "Kudu" }, continent: "afrika", country: "na", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
+  { id: "kolibri", name: { de: "Kolibri", en: "Hummingbird" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "zwei-beine-fluegel", birth: "eier", food: "nektar", cover: "federn", color: "bunt" },
+  { id: "kapuzineraffe", name: { de: "Kapuzineraffe", en: "Capuchin monkey" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "braun" },
+  { id: "klippspringer", name: { de: "Klippspringer", en: "Klipspringer" }, continent: "afrika", country: "na", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gelb-braun" },
+  { id: "krabbe", name: { de: "Krabbe", en: "Crab" }, continent: "ozeane", country: "nl", habitat: "meer", body: "zehn-beine", birth: "eier", food: "beides", cover: "panzer", color: "gruen" },
+  { id: "kabeljau", name: { de: "Kabeljau", en: "Cod" }, continent: "ozeane", country: "no", habitat: "meer", body: "flossen", birth: "eier", food: "fisch", cover: "schuppen", color: "grau" },
 
-  { id: "loewe", name: { de: "Löwe", en: "Lion" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gelb-braun" },
+  /* ── L ── europa 3, afrika 2, suedamerika 2, ozeane 2 ────────── */
   { id: "luchs", name: { de: "Luchs", en: "Lynx" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "rotbraun" },
+  { id: "lerche", name: { de: "Lerche", en: "Lark" }, continent: "europa", country: "de", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "braun" },
+  { id: "libelle", name: { de: "Libelle", en: "Dragonfly" }, continent: "europa", country: "ch", habitat: "suesswasser", body: "sechs-beine-fluegel", birth: "eier", food: "insekten", cover: "panzer", color: "blau-grau" },
+  { id: "loewe", name: { de: "Löwe", en: "Lion" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gelb-braun" },
+  { id: "leopard", name: { de: "Leopard", en: "Leopard" }, continent: "afrika", country: "tz", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gelb-gefleckt" },
   { id: "lama", name: { de: "Lama", en: "Llama" }, continent: "suedamerika", country: "bo", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "wolle", color: "weiss-braun" },
+  { id: "leguan", name: { de: "Leguan", en: "Iguana" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "eier", food: "pflanzen", cover: "schuppen", color: "gruen" },
+  { id: "lachs", name: { de: "Lachs", en: "Salmon" }, continent: "ozeane", country: "no", habitat: "meer", body: "flossen", birth: "eier", food: "fleisch", cover: "schuppen", color: "blau-grau" },
+  { id: "languste", name: { de: "Languste", en: "Spiny lobster" }, continent: "ozeane", country: "es", habitat: "meer", body: "zehn-beine", birth: "eier", food: "beides", cover: "panzer", color: "rotbraun" },
 
-  { id: "maus", name: { de: "Maus", en: "Mouse" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "grau" },
+  /* ── M ── europa 6, weltweit 2 ───────────────────────────────── */
   { id: "murmeltier", name: { de: "Murmeltier", en: "Marmot" }, continent: "europa", country: "ch", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "marienkaefer", name: { de: "Marienkäfer", en: "Ladybird" }, alt: { en: ["Ladybug"] }, continent: "europa", country: "de", habitat: "wiese", body: "sechs-beine-fluegel", birth: "eier", food: "insekten", cover: "panzer", color: "rot-schwarz" },
   { id: "molch", name: { de: "Molch", en: "Newt" }, continent: "europa", country: "ch", habitat: "suesswasser", body: "vier-beine", birth: "eier", food: "insekten", cover: "haut", color: "blau-orange" },
+  { id: "maulwurf", name: { de: "Maulwurf", en: "Mole" }, continent: "europa", country: "de", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "fell", color: "schwarz" },
+  { id: "marder", name: { de: "Marder", en: "Marten" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "braun" },
+  { id: "moewe", name: { de: "Möwe", en: "Seagull" }, continent: "europa", country: "nl", habitat: "meer", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "weiss" },
+  { id: "maus", name: { de: "Maus", en: "Mouse" }, continent: "weltweit", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "grau" },
+  { id: "muecke", name: { de: "Mücke", en: "Mosquito" }, continent: "weltweit", country: "de", habitat: "suesswasser", body: "sechs-beine-fluegel", birth: "eier", food: "nektar", cover: "panzer", color: "grau" },
+  { id: "mandrill", name: { de: "Mandrill", en: "Mandrill" }, continent: "afrika", country: "cm", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "bunt" },
+  { id: "marabu", name: { de: "Marabu", en: "Marabou" }, continent: "afrika", country: "tz", habitat: "savanne", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "schwarz-weiss" },
 
+  /* ── N ── afrika 2, europa 2, suedamerika 2 ─────────────────── */
   { id: "nashorn", name: { de: "Nashorn", en: "Rhinoceros" }, alt: { de: ["Rhinozeros"], en: ["Rhino"] }, continent: "afrika", country: "na", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "grau" },
   { id: "nilpferd", name: { de: "Nilpferd", en: "Hippopotamus" }, alt: { de: ["Flusspferd"], en: ["Hippo"] }, continent: "afrika", country: "tz", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "grau" },
   { id: "nachtigall", name: { de: "Nachtigall", en: "Nightingale" }, continent: "europa", country: "de", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "braun" },
+  { id: "nerz", name: { de: "Nerz", en: "Mink" }, continent: "europa", country: "ro", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "schwarz-braun" },
+  { id: "nutria", name: { de: "Nutria", en: "Nutria" }, continent: "suedamerika", country: "br", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
+  { id: "nasenbaer", name: { de: "Nasenbär", en: "Coati" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "rotbraun" },
 
+  /* ── O ── ozeane 2, europa 2 ─────────────────────────────────── */
   { id: "oktopus", name: { de: "Oktopus", en: "Octopus" }, alt: { de: ["Krake", "Octopus"] }, continent: "ozeane", country: "gr", habitat: "meer", body: "acht-arme", birth: "eier", food: "fleisch", cover: "haut", color: "rotbraun" },
-  { id: "otter", name: { de: "Otter", en: "Otter" }, continent: "europa", country: "at", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "fisch", cover: "fell", color: "braun" },
   { id: "orca", name: { de: "Orca", en: "Orca" }, continent: "ozeane", country: "no", habitat: "meer", body: "flossen", birth: "saeugetier", food: "fleisch", cover: "haut", color: "schwarz-weiss" },
+  { id: "otter", name: { de: "Otter", en: "Otter" }, continent: "europa", country: "at", habitat: "suesswasser", body: "vier-beine", birth: "saeugetier", food: "fisch", cover: "fell", color: "braun" },
+  { id: "ohrwurm", name: { de: "Ohrwurm", en: "Earwig" }, continent: "europa", country: "de", habitat: "wald", body: "sechs-beine", birth: "eier", food: "beides", cover: "panzer", color: "braun" },
+  { id: "oryx", name: { de: "Oryx", en: "Oryx" }, continent: "afrika", country: "na", habitat: "wueste", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "grau" },
+  { id: "okapi", name: { de: "Okapi", en: "Okapi" }, continent: "afrika", country: "cd", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz-braun" },
 
-  { id: "pinguin", name: { de: "Pinguin", en: "Penguin" }, continent: "afrika", country: "za", habitat: "meer", body: "zwei-beine", birth: "eier", food: "fisch", cover: "federn", color: "schwarz-weiss" },
+  /* ── P ── europa 2, afrika 2, asien 2, suedamerika 2, nordamerika 2 ── */
   { id: "pferd", name: { de: "Pferd", en: "Horse" }, continent: "europa", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
-  { id: "papagei", name: { de: "Papagei", en: "Parrot" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "bunt" },
+  { id: "papageitaucher", name: { de: "Papageitaucher", en: "Puffin" }, continent: "europa", country: "is", habitat: "meer", body: "zwei-beine-fluegel", birth: "eier", food: "fisch", cover: "federn", color: "schwarz-weiss" },
+  { id: "pinguin", name: { de: "Pinguin", en: "Penguin" }, continent: "afrika", country: "za", habitat: "meer", body: "zwei-beine", birth: "eier", food: "fisch", cover: "federn", color: "schwarz-weiss" },
+  { id: "pelikan", name: { de: "Pelikan", en: "Pelican" }, continent: "afrika", country: "tz", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "fisch", cover: "federn", color: "weiss" },
   { id: "panda", name: { de: "Panda", en: "Panda" }, continent: "asien", country: "cn", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz-weiss" },
+  { id: "pfau", name: { de: "Pfau", en: "Peacock" }, continent: "asien", country: "in", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "bunt" },
+  { id: "papagei", name: { de: "Papagei", en: "Parrot" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "bunt" },
+  { id: "piranha", name: { de: "Piranha", en: "Piranha" }, continent: "suedamerika", country: "br", habitat: "suesswasser", body: "flossen", birth: "eier", food: "fleisch", cover: "schuppen", color: "grau-rot" },
+  { id: "puma", name: { de: "Puma", en: "Puma" }, continent: "nordamerika", country: "us", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "gold-braun" },
+  { id: "praeriehund", name: { de: "Präriehund", en: "Prairie dog" }, continent: "nordamerika", country: "us", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "gold-braun" },
 
+  /* ── Q ── a thin letter: two animals, two continents ─────────── */
   { id: "qualle", name: { de: "Qualle", en: "Jellyfish" }, continent: "ozeane", country: "gr", habitat: "meer", body: "keine-beine", birth: "eier", food: "plankton", cover: "haut", color: "durchsichtig" },
   { id: "quokka", name: { de: "Quokka", en: "Quokka" }, continent: "australien", country: "au", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
 
+  /* ── R ── europa 4, weltweit 2 ───────────────────────────────── */
   { id: "reh", name: { de: "Reh", en: "Roe deer" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "robbe", name: { de: "Robbe", en: "Seal" }, alt: { de: ["Seehund"] }, continent: "europa", country: "nl", habitat: "meer", body: "flossen", birth: "saeugetier", food: "fisch", cover: "fell", color: "grau" },
   { id: "rabe", name: { de: "Rabe", en: "Raven" }, continent: "europa", country: "ch", habitat: "berge", body: "zwei-beine-fluegel", birth: "eier", food: "beides", cover: "federn", color: "schwarz" },
+  { id: "rotkehlchen", name: { de: "Rotkehlchen", en: "Robin" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "insekten", cover: "federn", color: "rot" },
+  { id: "ratte", name: { de: "Ratte", en: "Rat" }, continent: "weltweit", country: "de", habitat: "stadt", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "grau" },
+  { id: "regenwurm", name: { de: "Regenwurm", en: "Earthworm" }, continent: "weltweit", country: "de", habitat: "wiese", body: "keine-beine", birth: "eier", food: "pflanzen", cover: "haut", color: "rosa" },
 
+  /* ── S ── europa 6, ozeane 3, afrika 2 ──────────────────────── */
   { id: "schmetterling", name: { de: "Schmetterling", en: "Butterfly" }, continent: "europa", country: "de", habitat: "wiese", body: "sechs-beine-fluegel", birth: "eier", food: "nektar", cover: "panzer", color: "bunt" },
   { id: "schildkroete", name: { de: "Schildkröte", en: "Tortoise" }, continent: "europa", country: "gr", habitat: "wiese", body: "vier-beine", birth: "eier", food: "pflanzen", cover: "panzer", color: "gruen-braun" },
   { id: "schwan", name: { de: "Schwan", en: "Swan" }, continent: "europa", country: "ch", habitat: "suesswasser", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "weiss" },
   { id: "schaf", name: { de: "Schaf", en: "Sheep" }, continent: "europa", country: "ch", habitat: "zuhause", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "wolle", color: "weiss" },
   { id: "storch", name: { de: "Storch", en: "Stork" }, continent: "europa", country: "pl", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "schwarz-weiss" },
+  { id: "schnecke", name: { de: "Schnecke", en: "Snail" }, continent: "europa", country: "de", habitat: "wiese", body: "keine-beine", birth: "eier", food: "pflanzen", cover: "panzer", color: "braun" },
   { id: "seepferdchen", name: { de: "Seepferdchen", en: "Seahorse" }, continent: "ozeane", country: "au", habitat: "meer", body: "keine-beine", birth: "eier", food: "plankton", cover: "haut", color: "gelb" },
+  { id: "seestern", name: { de: "Seestern", en: "Starfish" }, continent: "ozeane", country: "no", habitat: "meer", body: "fuenf-arme", birth: "eier", food: "fleisch", cover: "haut", color: "rot" },
+  { id: "seeigel", name: { de: "Seeigel", en: "Sea urchin" }, continent: "ozeane", country: "gr", habitat: "meer", body: "keine-beine", birth: "eier", food: "pflanzen", cover: "stacheln", color: "schwarz" },
+  { id: "strauss", name: { de: "Strauss", en: "Ostrich" }, continent: "afrika", country: "ke", habitat: "savanne", body: "zwei-beine", birth: "eier", food: "pflanzen", cover: "federn", color: "schwarz-weiss" },
+  { id: "schimpanse", name: { de: "Schimpanse", en: "Chimpanzee" }, continent: "afrika", country: "cd", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "schwarz" },
 
-  { id: "tiger", name: { de: "Tiger", en: "Tiger" }, continent: "asien", country: "in", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "orange-schwarz" },
+  /* ── T ── europa 2, asien 2, suedamerika 2 ──────────────────── */
   { id: "taube", name: { de: "Taube", en: "Pigeon" }, continent: "europa", country: "ch", habitat: "stadt", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "grau" },
+  { id: "turmfalke", name: { de: "Turmfalke", en: "Kestrel" }, continent: "europa", country: "ch", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
+  { id: "tiger", name: { de: "Tiger", en: "Tiger" }, continent: "asien", country: "in", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "orange-schwarz" },
+  { id: "trampeltier", name: { de: "Trampeltier", en: "Two-humped camel" }, alt: { en: ["Bactrian camel"] }, continent: "asien", country: "cn", habitat: "wueste", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
   { id: "tukan", name: { de: "Tukan", en: "Toucan" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "bunt" },
+  { id: "tapir", name: { de: "Tapir", en: "Tapir" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "haut", color: "schwarz-weiss" },
 
+  /* ── U ── europa 2, and two singles the letter cannot pair ──── */
   { id: "uhu", name: { de: "Uhu", en: "Eagle owl" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
   { id: "unke", name: { de: "Unke", en: "Fire-bellied toad" }, continent: "europa", country: "de", habitat: "suesswasser", body: "vier-beine", birth: "eier", food: "insekten", cover: "haut", color: "grau-gelb" },
   { id: "uakari", name: { de: "Uakari", en: "Uakari" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "rotbraun" },
+  { id: "urial", name: { de: "Urial", en: "Urial" }, continent: "asien", country: "pk", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "wolle", color: "braun" },
 
+  /* ── V ── suedamerika 3, and one European the letter cannot pair ── */
   { id: "vogelspinne", name: { de: "Vogelspinne", en: "Tarantula" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "acht-beine", birth: "eier", food: "insekten", cover: "panzer", color: "schwarz-braun" },
+  { id: "vikunja", name: { de: "Vikunja", en: "Vicuña" }, continent: "suedamerika", country: "pe", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "wolle", color: "gold-braun" },
+  { id: "vampirfledermaus", name: { de: "Vampirfledermaus", en: "Vampire bat" }, continent: "suedamerika", country: "br", habitat: "regenwald", body: "zwei-beine-fluegel", birth: "saeugetier", food: "fleisch", cover: "fell", color: "grau" },
   { id: "vielfrass", name: { de: "Vielfrass", en: "Wolverine" }, continent: "europa", country: "no", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "schwarz-braun" },
 
+  /* ── W ── europa 4, arktis 2, ozeane 2, nordamerika 2 ───────── */
   { id: "wolf", name: { de: "Wolf", en: "Wolf" }, continent: "europa", country: "ch", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "fleisch", cover: "fell", color: "grau" },
+  { id: "waldkauz", name: { de: "Waldkauz", en: "Tawny owl" }, continent: "europa", country: "ch", habitat: "wald", body: "zwei-beine-fluegel", birth: "eier", food: "fleisch", cover: "federn", color: "braun" },
+  { id: "wildschwein", name: { de: "Wildschwein", en: "Wild boar" }, continent: "europa", country: "de", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "schwarz-braun" },
+  { id: "wachtel", name: { de: "Wachtel", en: "Quail" }, continent: "europa", country: "de", habitat: "wiese", body: "zwei-beine-fluegel", birth: "eier", food: "pflanzen", cover: "federn", color: "braun" },
+  { id: "wuehlmaus", name: { de: "Wühlmaus", en: "Vole" }, continent: "europa", country: "de", habitat: "wiese", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
+  { id: "walross", name: { de: "Walross", en: "Walrus" }, continent: "arktis", country: "no", habitat: "eis", body: "flossen", birth: "saeugetier", food: "fleisch", cover: "haut", color: "braun" },
+  { id: "weisswal", name: { de: "Weisswal", en: "White whale" }, alt: { de: ["Beluga"], en: ["Beluga"] }, continent: "arktis", country: "no", habitat: "meer", body: "flossen", birth: "saeugetier", food: "fisch", cover: "haut", color: "weiss" },
   { id: "wal", name: { de: "Wal", en: "Whale" }, alt: { de: ["Blauwal"], en: ["Blue whale"] }, continent: "ozeane", country: "is", habitat: "meer", body: "flossen", birth: "saeugetier", food: "plankton", cover: "haut", color: "blau-grau" },
+  { id: "wellhornschnecke", name: { de: "Wellhornschnecke", en: "Whelk" }, continent: "ozeane", country: "nl", habitat: "meer", body: "keine-beine", birth: "eier", food: "fleisch", cover: "panzer", color: "braun" },
   { id: "waschbaer", name: { de: "Waschbär", en: "Raccoon" }, continent: "nordamerika", country: "us", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "beides", cover: "fell", color: "grau" },
+  { id: "wapiti", name: { de: "Wapiti", en: "Wapiti" }, continent: "nordamerika", country: "us", habitat: "wald", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "braun" },
 
+  /* ── Y ── one animal, and nothing honest to pair it with ────── */
   { id: "yak", name: { de: "Yak", en: "Yak" }, alt: { de: ["Jak"] }, continent: "asien", country: "cn", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz" },
 
+  /* ── Z ── europa 3, afrika 2 ────────────────────────────────── */
+  { id: "ziege", name: { de: "Ziege", en: "Goat" }, continent: "europa", country: "ch", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "weiss" },
+  { id: "zikade", name: { de: "Zikade", en: "Cicada" }, continent: "europa", country: "es", habitat: "wald", body: "sechs-beine-fluegel", birth: "eier", food: "pflanzen", cover: "panzer", color: "gruen" },
+  { id: "zander", name: { de: "Zander", en: "Zander" }, alt: { en: ["Pikeperch"] }, continent: "europa", country: "de", habitat: "suesswasser", body: "flossen", birth: "eier", food: "fisch", cover: "schuppen", color: "gruen-braun" },
   { id: "zebra", name: { de: "Zebra", en: "Zebra" }, continent: "afrika", country: "ke", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "schwarz-weiss" },
-  { id: "ziege", name: { de: "Ziege", en: "Goat" }, continent: "europa", country: "ch", habitat: "berge", body: "vier-beine", birth: "saeugetier", food: "pflanzen", cover: "fell", color: "weiss" }
+  { id: "zwergmanguste", name: { de: "Zwergmanguste", en: "Dwarf mongoose" }, continent: "afrika", country: "tz", habitat: "savanne", body: "vier-beine", birth: "saeugetier", food: "insekten", cover: "fell", color: "braun" }
 ];

--- a/tierraten/js/app.js
+++ b/tierraten/js/app.js
@@ -1,15 +1,15 @@
 // app.js — controller: owns the state, handles every interaction through
 // event delegation, persists via storage.js and draws via ui.js.
 
-import { render } from "./ui.js?v=1";
+import { render } from "./ui.js?v=2";
 import {
   CLUE_COUNT, ROUND_SIZES, MASTERY_RUNS,
   animalById, nameOf, matchesName
-} from "./data.js?v=1";
-import { t, setLanguage } from "./i18n.js?v=1";
-import * as storage from "./storage.js?v=1";
-import { pickAnimals, optionsFor, nextLetter } from "./round.js?v=1";
-import { award, levelFor, xpForRound } from "./game.js?v=1";
+} from "./data.js?v=2";
+import { t, setLanguage } from "./i18n.js?v=2";
+import * as storage from "./storage.js?v=2";
+import { pickAnimals, optionsFor, nextLetter } from "./round.js?v=2";
+import { award, levelFor, xpForRound } from "./game.js?v=2";
 
 const state = {
   view: "home",

--- a/tierraten/js/data.js
+++ b/tierraten/js/data.js
@@ -1,7 +1,7 @@
 // data.js — settings vocabulary, the clue ladder, and the selectors the
 // rest of the app reads the fact table through. No DOM, no strings.
 
-import { ANIMALS } from "./animals.js?v=1";
+import { ANIMALS } from "./animals.js?v=2";
 
 export const LANGUAGES = [
   { code: "de", label: "Deutsch", htmlLang: "de-CH" },

--- a/tierraten/js/game.js
+++ b/tierraten/js/game.js
@@ -3,7 +3,7 @@
 // medal is a function of the stored counters rather than an event flag,
 // so state and medals cannot drift apart.
 
-import { CLUE_COUNT } from "./data.js?v=1";
+import { CLUE_COUNT } from "./data.js?v=2";
 
 // A solved animal is worth a base plus whatever clues were left unused.
 // Guessing early is harder, not faster: the clock plays no part here, and

--- a/tierraten/js/i18n.js
+++ b/tierraten/js/i18n.js
@@ -3,9 +3,9 @@
 // network. German is the fallback for a missing key; a missing key is a
 // bug, and `t` returns the key itself so it shows up instead of hiding.
 
-import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=1";
-import { de } from "./i18n/de.js?v=1";
-import { en } from "./i18n/en.js?v=1";
+import { LANGUAGES, DEFAULT_LANGUAGE } from "./data.js?v=2";
+import { de } from "./i18n/de.js?v=2";
+import { en } from "./i18n/en.js?v=2";
 
 export const TABLES = { de, en };
 

--- a/tierraten/js/i18n/de.js
+++ b/tierraten/js/i18n/de.js
@@ -149,6 +149,7 @@ export const de = {
   countryCa: "Kanada",
   countryCd: "Demokratische Republik Kongo",
   countryCh: "Schweiz",
+  countryCm: "Kamerun",
   countryCn: "China",
   countryDe: "Deutschland",
   countryEg: "Ägypten",
@@ -162,9 +163,9 @@ export const de = {
   countryNl: "Niederlande",
   countryNo: "Norwegen",
   countryPe: "Peru",
+  countryPk: "Pakistan",
   countryPl: "Polen",
   countryRo: "Rumänien",
-  countrySy: "Syrien",
   countryTz: "Tansania",
   countryUs: "USA",
   countryZa: "Südafrika",
@@ -191,6 +192,8 @@ export const de = {
   bodySechsBeine: "Sechs Beine",
   bodySechsBeineFluegel: "Sechs Beine und Flügel",
   bodyAchtBeine: "Acht Beine",
+  bodyZehnBeine: "Zehn Beine",
+  bodyFuenfArme: "Fünf Arme",
   bodyAchtArme: "Acht Arme",
 
   /* Value labels: young */
@@ -240,5 +243,6 @@ export const de = {
   colorOrangeWeiss: "Orange und weiss",
   colorWeissBraun: "Weiss und braun",
   colorGrauGelb: "Grau mit gelbem Bauch",
+  colorGrauRot: "Grau mit rotem Bauch",
   colorBlauOrange: "Blau mit orangem Bauch"
 };

--- a/tierraten/js/i18n/en.js
+++ b/tierraten/js/i18n/en.js
@@ -148,6 +148,7 @@ export const en = {
   countryCa: "Canada",
   countryCd: "Democratic Republic of the Congo",
   countryCh: "Switzerland",
+  countryCm: "Cameroon",
   countryCn: "China",
   countryDe: "Germany",
   countryEg: "Egypt",
@@ -161,9 +162,9 @@ export const en = {
   countryNl: "Netherlands",
   countryNo: "Norway",
   countryPe: "Peru",
+  countryPk: "Pakistan",
   countryPl: "Poland",
   countryRo: "Romania",
-  countrySy: "Syria",
   countryTz: "Tanzania",
   countryUs: "United States",
   countryZa: "South Africa",
@@ -190,6 +191,8 @@ export const en = {
   bodySechsBeine: "Six legs",
   bodySechsBeineFluegel: "Six legs and wings",
   bodyAchtBeine: "Eight legs",
+  bodyZehnBeine: "Ten legs",
+  bodyFuenfArme: "Five arms",
   bodyAchtArme: "Eight arms",
 
   /* Value labels: young */
@@ -239,5 +242,6 @@ export const en = {
   colorOrangeWeiss: "Orange and white",
   colorWeissBraun: "White and brown",
   colorGrauGelb: "Grey with a yellow belly",
+  colorGrauRot: "Grey with a red belly",
   colorBlauOrange: "Blue with an orange belly"
 };

--- a/tierraten/js/round.js
+++ b/tierraten/js/round.js
@@ -2,10 +2,10 @@
 // functions over the fact table and the stored progress; no DOM, no
 // strings, no persistence.
 
-import { ANIMALS } from "./animals.js?v=1";
+import { ANIMALS } from "./animals.js?v=2";
 import {
-  ALPHABET, OPTION_COUNT, animalsForLetter, letterOf, letterIndex
-} from "./data.js?v=1";
+  ALPHABET, CLUES, OPTION_COUNT, animalsForLetter, letterOf, letterIndex
+} from "./data.js?v=2";
 
 function shuffled(list) {
   const out = list.slice();
@@ -30,18 +30,54 @@ export function pickAnimals(letter, lang, size, data) {
   return [...fresh, ...known].slice(0, size).map((a) => a.id);
 }
 
-// The names offered in choose mode: the answer plus other animals, taken
-// from the same letter first so the choice is decided by the clues and
-// not by the initial. A thin letter borrows from the rest of the pool.
+// How far down the ladder two animals stay indistinguishable: the number
+// of leading clues on which they agree. Two African animals score at
+// least 1, two African animals from the same country at least 2. It
+// counts the *leading* run, not the total, because that is where the
+// child actually gets to stop reading.
+export function sharedPrefix(a, b) {
+  let n = 0;
+  for (const clue of CLUES) {
+    if (!clue.field || a[clue.field] !== b[clue.field]) break;
+    n += 1;
+  }
+  return n;
+}
+
+// The names offered in choose mode: the answer plus other animals from
+// the same letter, picked so the early clues cannot split them.
+//
+// Picking at random is what made the game give itself away — a letter
+// holding one African animal would offer it beside three from three
+// other continents, and clue one was the whole game. Ranking candidates
+// by how long they stay indistinguishable puts the answer's own
+// continent on the board first, so the child has to go deeper. Ties stay
+// shuffled, so the same animal does not always come with the same
+// company.
+//
+// A letter too thin to fill the board borrows from the rest of the pool.
+// The initial gives those away, but a letter with one animal has no
+// honest alternative, and the borrowed names are ranked the same way so
+// the clues still have work to do.
 export function optionsFor(animalId, lang, count = OPTION_COUNT) {
   const answer = ANIMALS.find((a) => a.id === animalId);
   if (!answer) return [];
   const letter = letterOf(answer, lang);
-  const sameLetter = shuffled(
+  const byCloseness = (list) => shuffled(list)
+    .map((a) => ({ a, score: sharedPrefix(answer, a) }))
+    .sort((x, y) => y.score - x.score)
+    .map((x) => x.a);
+
+  const sameLetter = byCloseness(
     animalsForLetter(letter, lang).filter((a) => a.id !== animalId)
   );
-  const rest = shuffled(ANIMALS.filter((a) => a.id !== animalId && letterOf(a, lang) !== letter));
-  const others = [...sameLetter, ...rest].slice(0, count - 1);
+  const others = sameLetter.length >= count - 1
+    ? sameLetter.slice(0, count - 1)
+    : [
+      ...sameLetter,
+      ...byCloseness(ANIMALS.filter((a) => a.id !== animalId && letterOf(a, lang) !== letter))
+        .slice(0, count - 1 - sameLetter.length)
+    ];
   return shuffled([answer, ...others]).map((a) => a.id);
 }
 

--- a/tierraten/js/storage.js
+++ b/tierraten/js/storage.js
@@ -4,8 +4,8 @@
 import {
   LANGUAGES, ANSWER_MODES, ROUND_SIZES,
   DEFAULT_LANGUAGE, DEFAULT_ANSWER_MODE, DEFAULT_ROUND_SIZE
-} from "./data.js?v=1";
-import { ANIMALS } from "./animals.js?v=1";
+} from "./data.js?v=2";
+import { ANIMALS } from "./animals.js?v=2";
 
 const KEY = "tierraten.state";
 

--- a/tierraten/js/ui.js
+++ b/tierraten/js/ui.js
@@ -3,15 +3,15 @@
 // attribute that app.js handles. Every label comes from i18n, so no copy
 // lives in this file.
 
-import { icon } from "./icons.js?v=1";
+import { icon } from "./icons.js?v=2";
 import {
   LANGUAGES, ANSWER_MODES, ROUND_SIZES, CLUES, CLUE_COUNT,
   animalById, nameOf, secondLetterOf, valueKey, clueLabelKey
-} from "./data.js?v=1";
-import { t } from "./i18n.js?v=1";
-import { escapeHtml } from "./util.js?v=1";
-import { letterRows } from "./round.js?v=1";
-import { MEDALS, levelFor, medalProgress } from "./game.js?v=1";
+} from "./data.js?v=2";
+import { t } from "./i18n.js?v=2";
+import { escapeHtml } from "./util.js?v=2";
+import { letterRows } from "./round.js?v=2";
+import { MEDALS, levelFor, medalProgress } from "./game.js?v=2";
 
 export function render(state) {
   const app = document.getElementById("app");

--- a/tierraten/tests/e2e.test.mjs
+++ b/tierraten/tests/e2e.test.mjs
@@ -21,13 +21,14 @@ import { dirname, join, extname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   ANIMALS, CONTINENTS, HABITATS, BODIES, BIRTHS, FOODS, COVERS, COLORS, COUNTRIES
-} from "../js/animals.js?v=1";
+} from "../js/animals.js?v=2";
 import {
   LANGUAGES, ALPHABET, CLUES, CLUE_COUNT, ROUND_SIZES, OPTION_COUNT, MASTERY_RUNS,
   nameOf, letterOf, secondLetterOf, valueKey, clueLabelKey, acceptedForms, matchesName
-} from "../js/data.js?v=1";
-import { TABLES } from "../js/i18n.js?v=1";
-import { MEDALS, LEVELS, levelFor, xpForAnimal, SOLVE_BASE, REVEAL_XP } from "../js/game.js?v=1";
+} from "../js/data.js?v=2";
+import { TABLES } from "../js/i18n.js?v=2";
+import { MEDALS, LEVELS, levelFor, xpForAnimal, SOLVE_BASE, REVEAL_XP } from "../js/game.js?v=2";
+import { optionsFor, sharedPrefix } from "../js/round.js?v=2";
 
 const TESTS_DIR = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = join(TESTS_DIR, "..");
@@ -190,6 +191,79 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   check("spaces and case fall away", matchesName(roe, "en", "  roe   DEER "));
 }
 
+/* ── The first clue must not be the whole game ──────────────────────
+   This is the property the ladder lives or dies by. A letter holding a
+   single African animal offers it beside three animals from three other
+   continents, and "Afrika" ends the round before it starts. Two things
+   have to hold: the fact table stocks letters in continent pairs, and
+   the option picker actually puts the partner on the board. The second
+   is the one that is easy to regress, so it is checked against every
+   animal in both languages rather than sampled. */
+{
+  const report = [];
+  const problems = [];
+  for (const lang of LANGUAGES) {
+    let alone = 0;
+    let decided = 0;
+    for (const animal of ANIMALS) {
+      const letter = letterOf(animal, lang.code);
+      const pool = ANIMALS.filter((a) => letterOf(a, lang.code) === letter && a.id !== animal.id);
+      const partnered = pool.some((a) => a.continent === animal.continent);
+      if (!partnered) alone += 1;
+      const options = optionsFor(animal.id, lang.code).map((id) => ANIMALS.find((a) => a.id === id));
+      const shares = options.some((o) => o.id !== animal.id && o.continent === animal.continent);
+      if (!shares) {
+        decided += 1;
+        // Not sharing is only forgivable when the letter has nothing to
+        // share with. Anything else is the picker throwing the round.
+        if (partnered) problems.push(`${lang.code}: ${nameOf(animal, lang.code)} was offered no ${animal.continent} company`);
+      }
+    }
+    report.push(`${lang.code}: ${decided}/${ANIMALS.length} boards split by clue 1, ${alone} animals alone in their letter`);
+  }
+  check("the picker never wastes a same-continent partner the letter has",
+    problems.length === 0, problems.slice(0, 5).join(" | "));
+  console.log(`      ${report.join(" | ")}`);
+
+  // The floor the content currently clears. Adding animals may only
+  // improve it; a change that pushes it back is a regression in the one
+  // thing this game is about.
+  const aloneIn = (code) => ANIMALS.filter((animal) => {
+    const letter = letterOf(animal, code);
+    return !ANIMALS.some((a) => a.id !== animal.id && letterOf(a, code) === letter && a.continent === animal.continent);
+  }).length;
+  check("German keeps every animal but the thin letters in a continent pair",
+    aloneIn("de") <= 10, `${aloneIn("de")} alone`);
+  check("English keeps the same within reach of its own alphabet",
+    aloneIn("en") <= 25, `${aloneIn("en")} alone`);
+}
+
+/* ── Distractors stay close ─────────────────────────────────────────
+   Beyond the continent, an option set that agrees on more of the early
+   ladder is a set the child has to read further to split. */
+{
+  const problems = [];
+  for (const lang of LANGUAGES) {
+    for (const animal of ANIMALS) {
+      const letter = letterOf(animal, lang.code);
+      const pool = ANIMALS.filter((a) => letterOf(a, lang.code) === letter && a.id !== animal.id);
+      if (pool.length < OPTION_COUNT - 1) continue;
+      const best = pool.map((a) => sharedPrefix(animal, a)).sort((a, b) => b - a).slice(0, OPTION_COUNT - 1);
+      const got = optionsFor(animal.id, lang.code)
+        .filter((id) => id !== animal.id)
+        .map((id) => sharedPrefix(animal, ANIMALS.find((a) => a.id === id)))
+        .sort((a, b) => b - a);
+      if (got.join(",") !== best.join(",")) {
+        problems.push(`${lang.code}: ${nameOf(animal, lang.code)} got [${got}] not [${best}]`);
+      }
+    }
+  }
+  check("the option set is always the closest the letter can offer",
+    problems.length === 0, problems.slice(0, 5).join(" | "));
+  check("closeness is measured on the leading clues only",
+    sharedPrefix(ANIMALS[0], ANIMALS[0]) === CLUES.filter((c) => c.field).length);
+}
+
 /* ── Alphabet coverage ──────────────────────────────────────────────
    Every letter that holds animals must hold enough of them for the
    round the settings can ask for, or say plainly that it holds none. */
@@ -208,6 +282,15 @@ const jsFiles = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) =
   check("at most one letter is empty per language",
     empty.de.length <= 1 && empty.en.length <= 1,
     `de ${empty.de.join(",")} / en ${empty.en.join(",")}`);
+  // A letter that cannot fill the board has to borrow names whose
+  // initial gives them away, so thin letters are worth counting.
+  const thin = (code) => ALPHABET.filter((L) => {
+    const n = ANIMALS.filter((a) => letterOf(a, code) === L).length;
+    return n > 0 && n < OPTION_COUNT;
+  });
+  check("only a handful of letters are too thin to fill the board",
+    thin("de").length <= 4 && thin("en").length <= 7,
+    `de ${thin("de").join(",")} / en ${thin("en").join(",")}`);
 }
 
 /* ── XP and levels ──────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #34. The clue ladder was giving itself away: a letter holding a single African animal offered it beside three animals from three other continents, so "Afrika" ended the round before it started.

**Live:** https://lfdave.github.io/small-apps/tierraten/index.html?r=20260806-2 (after merge and a Pages redeploy)

## The problem, measured

40 of the 84 animals were the only one in their letter with their continent. On top of that, `optionsFor` picked the three distractors at random, so it threw away even the pairs that did exist.

## Two changes, and they only work together

**The fact table grows from 84 to 172 animals, stocked in continent pairs within each letter.** A species is now added with a partner from its own continent or not at all. German is down to 10 animals still standing alone, all in the letters the animal kingdom does not fill (C, J, Q, U, V, Y). English, whose alphabet cuts the same set differently, is down to 25 of 172 from 32 of 84.

**`optionsFor` ranks instead of sampling.** Candidates are scored by `sharedPrefix` — the run of *leading* clues they share with the answer — and the closest fill the board. Two African animals score at least 1, two African animals from the same country at least 2. Ties stay shuffled, so an animal does not always arrive with the same company.

| | before | after |
| --- | --- | --- |
| animals | 84 | 172 |
| boards split by clue 1, German | most of them | 3 / 172 |
| boards split by clue 1, English | most of them | 13 / 172 |

In none of the remaining cases did the letter hold a partner the picker could have used — the suite checks that for every animal in both languages.

What it looks like now: clue one says **Europa**, and the four names are Ameise, Amsel, Austernfischer, Auerhahn. All four are European, two of them even share the second letter, so the child has to read down to habitat and covering.

## Content notes

Ten of the new animals were picked to pair a continent in German and a different one in English at the same time (Erdferkel/Aardvark pairs Africa under German E and English A; Austernfischer/Oystercatcher pairs Europe under German A and English O; and so on). Two English names moved to the letter where their continent already had company — Beluga → White whale, Bactrian camel → Two-humped camel — both keeping the old name as an accepted spelling.

Facts follow the same rules as before: ordinary checkable ones, `country` an example the species really occurs in, and nothing that would need a hedge to fit the mammal-or-egg step (which is why there are still no vipers, no live-bearing sharks and no fire salamander).

New value ids: **ten legs** and **five arms** for the crustaceans and the starfish, a **grey with a red belly** colour, **Cameroon** and **Pakistan**. Syria left with the hamster, which now sits with the other animals that live alongside people.

## Tests

Two new blocks, both run against every animal in both languages rather than sampled:

- the picker never leaves a same-continent partner on the bench;
- the option set is always the closest the letter can offer, by `sharedPrefix`.

Plus floors on how many animals stand alone (≤10 German, ≤25 English) and how many letters are too thin to fill the board, so a later change can improve this but not quietly regress it. The whole suite passes. Cache-busting version bumped to 2 across every asset.

PRD, app CLAUDE.md, app README and the repo README updated in the same change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pt7UtX72rmoMiUUUSXoDHM)_